### PR TITLE
Fix syntax errors in conditioning and main

### DIFF
--- a/conditioning.py
+++ b/conditioning.py
@@ -16,7 +16,6 @@ style_tag_map = {
 
 # Goal tags
 goal_tag_map = {
-    goal_tag_map = {
     "power": [
         "explosive", "rate_of_force", "triple_extension", "horizontal_power",
         "plyometric", "elastic", "lateral_power", "deadlift",

--- a/main.py
+++ b/main.py
@@ -38,11 +38,11 @@ GOAL_NORMALIZER = {
     "Grip Strength": "grip",
     "Posterior Chain": "posterior_chain",
     "Knees": "quad_dominant",
-    "Neck": "neck"
-    "Grappling": "grappling"
-    "Striking": "striking"
-    "Injury Prevention": "injury prevention"
-    "Mental Resilience": "mental resilience"
+    "Neck": "neck",
+    "Grappling": "grappling",
+    "Striking": "striking",
+    "Injury Prevention": "injury prevention",
+    "Mental Resilience": "mental resilience",
     "Skill Refinement": "skill refinement"
 }
 # Auth


### PR DESCRIPTION
## Summary
- remove duplicated variable declaration in `conditioning.py`
- correct commas in `GOAL_NORMALIZER` dictionary in `main.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ba37ecc4832e95e0b468d762c64c