### PR TITLE
Add novelty filters for conditioning block

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ async def handle_submission(request: Request):
     taper_flags = {**training_context, "phase": "TAPER", "prev_exercises": spp_ex_names}
     taper_block = generate_strength_block(flags=taper_flags, weaknesses=training_context["weaknesses"])
     strength_block = "\n\n".join([gpp_block["block"], spp_block["block"], taper_block["block"]])
-    conditioning_block = generate_conditioning_block(training_context)
+    conditioning_block, _ = generate_conditioning_block(training_context)
     recovery_block = generate_recovery_block(training_context)
     nutrition_block = generate_nutrition_block(flags=training_context)
     injury_sub_block = generate_injury_subs(injury_string=injuries, exercise_data=exercise_bank)


### PR DESCRIPTION
## Summary
- enforce unique conditioning drills and track them per phase
- drop high CNS drills in TAPER except low fatigue alactic needs
- expose selected drill names and update main

## Testing
- `python3 -m py_compile strength.py conditioning.py main.py recovery.py nutrition.py mindset_module.py training_context.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c0c7f82c832e93f85f9c81a5dcb2