### PR TITLE
Integrate mindset cues per phase

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,12 @@ exercise_bank = json.loads(Path("exercise_bank.json").read_text())
 
 # Modules
 from training_context import allocate_sessions, normalize_equipment_list
-from mindset_module import classify_mental_block, get_mindset_by_phase, get_mental_protocols
+from mindset_module import (
+    classify_mental_block,
+    get_mindset_by_phase,
+    get_mental_protocols,
+    get_phase_mindset_cues,
+)
 from strength import generate_strength_block
 from conditioning import generate_conditioning_block
 from recovery import generate_recovery_block
@@ -177,25 +182,37 @@ async def handle_submission(request: Request):
     # Module generation
     mental_block = get_mindset_by_phase(phase, training_context)
     mental_strategies = get_mental_protocols(training_context["mental_block"])
+    phase_mindset_cues = get_phase_mindset_cues(training_context["mental_block"])
 
     # === Strength blocks per phase with repeat filtering ===
     gpp_flags = {**training_context, "phase": "GPP"}
-    gpp_block = generate_strength_block(flags=gpp_flags, weaknesses=training_context["weaknesses"])
+    gpp_block = generate_strength_block(
+        flags=gpp_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("GPP")
+    )
     gpp_ex_names = [ex["name"] for ex in gpp_block["exercises"]]
 
     spp_flags = {**training_context, "phase": "SPP", "prev_exercises": gpp_ex_names}
-    spp_block = generate_strength_block(flags=spp_flags, weaknesses=training_context["weaknesses"])
+    spp_block = generate_strength_block(
+        flags=spp_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("SPP")
+    )
     spp_ex_names = [ex["name"] for ex in spp_block["exercises"]]
 
     taper_flags = {**training_context, "phase": "TAPER", "prev_exercises": spp_ex_names}
-    taper_block = generate_strength_block(flags=taper_flags, weaknesses=training_context["weaknesses"])
+    taper_block = generate_strength_block(
+        flags=taper_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("TAPER")
+    )
     strength_block = "\n\n".join([gpp_block["block"], spp_block["block"], taper_block["block"]])
     conditioning_block, _ = generate_conditioning_block(training_context)
     recovery_block = generate_recovery_block(training_context)
     nutrition_block = generate_nutrition_block(flags=training_context)
     injury_sub_block = generate_injury_subs(injury_string=injuries, exercise_data=exercise_bank)
 
-    print("== NUTRITION BLOCK ==\n", nutrition_block)
 
     prompt = f"""
 # CONTEXT BLOCKS – Use these to build the plan

--- a/mindset_module.py
+++ b/mindset_module.py
@@ -173,3 +173,18 @@ def get_mental_protocols(blocks: list) -> str:
         sections.append("\n".join(phase_lines))
 
     return "\n\n".join(sections)
+
+def get_phase_mindset_cues(blocks) -> dict:
+    """Return a short cue per phase based on top mental blocks."""
+    if isinstance(blocks, str):
+        blocks = [blocks]
+    blocks = blocks[:2] if blocks else ["generic"]
+
+    cues = {}
+    for phase in ["GPP", "SPP", "TAPER"]:
+        tips = []
+        for block in blocks:
+            tip = mindset_bank.get(phase, {}).get(block, mindset_bank[phase]["generic"])
+            tips.append(f"{block.title()}: {tip}")
+        cues[phase] = " | ".join(tips)
+    return cues

--- a/strength.py
+++ b/strength.py
@@ -52,7 +52,18 @@ def equipment_score_adjust(entry_equip, user_equipment, known_equipment):
 
 exercise_bank = json.loads(Path("exercise_bank.json").read_text())
 
-def generate_strength_block(*, flags: dict, weaknesses=None):
+def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
+    """Create a strength training block for a single phase.
+
+    Args:
+        flags: Training context parameters.
+        weaknesses: List of athlete weaknesses to bias exercise selection.
+        mindset_cue: Short mindset habit or drill to append to the block.
+
+    Returns:
+        Dict with generated block text, session count, preferred tags and
+        chosen exercises.
+    """
     phase = flags.get("phase", "GPP").upper()
     injuries = flags.get("injuries", [])
     fatigue = flags.get("fatigue", "low")
@@ -324,6 +335,8 @@ def generate_strength_block(*, flags: dict, weaknesses=None):
     ]
     if fatigue_note:
         strength_output.append(f"**Adjustment:** {fatigue_note}")
+    if mindset_cue:
+        strength_output.append(f"**Mindset Cue:** {mindset_cue}")
 
     all_tags = []
     for ex in base_exercises:


### PR DESCRIPTION
## Summary
- import full mental strategy API
- compute mindset strategies and cues after context build
- inject `mental_block` and `mental_strategies` sections back into the prompt

## Testing
- `python -m py_compile mindset_module.py strength.py main.py`
- `python -m py_compile conditioning.py recovery.py nutrition.py training_context.py`


------
https://chatgpt.com/codex/tasks/task_e_684568a49a5c832eabeb21d1d6c26a52