### PR TITLE
Integrate mindset cues while preserving template

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,12 @@ exercise_bank = json.loads(Path("exercise_bank.json").read_text())
 
 # Modules
 from training_context import allocate_sessions, normalize_equipment_list
-from mindset_module import classify_mental_block, get_mindset_by_phase, get_mental_protocols
+from mindset_module import (
+    classify_mental_block,
+    get_mindset_by_phase,
+    get_mental_protocols,
+    get_phase_mindset_cues,
+)
 from strength import generate_strength_block
 from conditioning import generate_conditioning_block
 from recovery import generate_recovery_block
@@ -177,27 +182,53 @@ async def handle_submission(request: Request):
     # Module generation
     mental_block = get_mindset_by_phase(phase, training_context)
     mental_strategies = get_mental_protocols(training_context["mental_block"])
+    phase_mindset_cues = get_phase_mindset_cues(training_context["mental_block"])
 
     # === Strength blocks per phase with repeat filtering ===
     gpp_flags = {**training_context, "phase": "GPP"}
-    gpp_block = generate_strength_block(flags=gpp_flags, weaknesses=training_context["weaknesses"])
+    gpp_block = generate_strength_block(
+        flags=gpp_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("GPP"),
+    )
     gpp_ex_names = [ex["name"] for ex in gpp_block["exercises"]]
 
     spp_flags = {**training_context, "phase": "SPP", "prev_exercises": gpp_ex_names}
-    spp_block = generate_strength_block(flags=spp_flags, weaknesses=training_context["weaknesses"])
+    spp_block = generate_strength_block(
+        flags=spp_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("SPP"),
+    )
     spp_ex_names = [ex["name"] for ex in spp_block["exercises"]]
 
     taper_flags = {**training_context, "phase": "TAPER", "prev_exercises": spp_ex_names}
-    taper_block = generate_strength_block(flags=taper_flags, weaknesses=training_context["weaknesses"])
+    taper_block = generate_strength_block(
+        flags=taper_flags,
+        weaknesses=training_context["weaknesses"],
+        mindset_cue=phase_mindset_cues.get("TAPER"),
+    )
     strength_block = "\n\n".join([gpp_block["block"], spp_block["block"], taper_block["block"]])
+
     conditioning_block, _ = generate_conditioning_block(training_context)
     recovery_block = generate_recovery_block(training_context)
     nutrition_block = generate_nutrition_block(flags=training_context)
     injury_sub_block = generate_injury_subs(injury_string=injuries, exercise_data=exercise_bank)
 
-    print("== NUTRITION BLOCK ==\n", nutrition_block)
 
-    prompt = f"""
+    mental_strategies_block = f"""## MENTAL PERFORMANCE STRATEGY
+Use the insights below for phase-specific mindset coaching. Integrate them into each phase’s training logic.
+
+→ Use the `Mindset Cue` provided to address the athlete’s top 1–2 mental blocks.
+→ Each phase (GPP, SPP, TAPER) should include 1 short mindset habit (journal cue, visual drill, recovery ritual, etc).
+→ For example: If the block is **pressure**, GPP might include journaling cues, SPP should introduce pressure simulation drills.
+→ You must include this in each training phase block — do not separate it as a stand-alone mindset section.
+→ If no specific block was detected, fallback to general preparation cues.
+→ Do **not** duplicate cues across phases unless justified.
+
+{mental_strategies}
+"""
+
+    prompt = mental_strategies_block + "\n" + f"""
 # CONTEXT BLOCKS – Use these to build the plan
 
 ## SAFETY
@@ -251,9 +282,10 @@ Athlete Profile:
 - Available S&C Days: {available_days}
 - Weaknesses: {weak_areas}
 - Key Goals: {key_goals}
-- Mindset Challenges: {mental_block}
+- Mindset Challenges: {', '.join(training_context['mental_block'])}
 - Extra Notes: {notes}
 """
+
 
     try:
         response = openai.chat.completions.create(

--- a/main.py
+++ b/main.py
@@ -215,33 +215,40 @@ async def handle_submission(request: Request):
     injury_sub_block = generate_injury_subs(injury_string=injuries, exercise_data=exercise_bank)
 
 
-    mental_strategies_block = f"""## MENTAL PERFORMANCE STRATEGY
-Use the insights below for phase-specific mindset coaching. Integrate them into each phase’s training logic.
+    # Mental Block Strategy Injection Per Phase
+def build_mindset_prompt(phase_name: str):
+    if training_context["mental_block"] and training_context["mental_block"][0].lower() != "generic":
+        cues = get_phase_mindset_cues(training_context["mental_block"])
+        return f"\n🚫 **Mental Block – {', '.join(training_context['mental_block']).upper()} ({phase_name} Phase)**:\n{cues.get(phase_name, '')}\n"
+    else:
+        return f"\n🧠 **Mental Strategy ({phase_name} Phase)**:\n{get_mindset_by_phase(phase_name, training_context)}\n"
 
-→ Use the `Mindset Cue` provided to address the athlete’s top 1–2 mental blocks.
-→ Each phase (GPP, SPP, TAPER) should include 1 short mindset habit (journal cue, visual drill, recovery ritual, etc).
-→ For example: If the block is **pressure**, GPP might include journaling cues, SPP should introduce pressure simulation drills.
-→ You must include this in each training phase block — do not separate it as a stand-alone mindset section.
-→ If no specific block was detected, fallback to general preparation cues.
-→ Do **not** duplicate cues across phases unless justified.
+# Add block-level mindset cues into each phase manually (this is what GPT actually sees)
+gpp_mindset = build_mindset_prompt("GPP")
+spp_mindset = build_mindset_prompt("SPP")
+taper_mindset = build_mindset_prompt("TAPER")
 
-{mental_strategies}
-"""
-
-    prompt = mental_strategies_block + "\n" + f"""
+prompt = f"""
 # CONTEXT BLOCKS – Use these to build the plan
 
 ## SAFETY
 Avoid training through pain. Prioritize recovery. Emphasize technique.
 
 ## MINDSET
-{mental_block}
-
-## MENTAL PROTOCOLS
-{mental_strategies}
+Top Block(s): {', '.join(training_context['mental_block']).title()}
 
 ## STRENGTH
-{strength_block}
+### GPP
+{gpp_mindset}
+{gpp_block["block"]}
+
+### SPP
+{spp_mindset}
+{spp_block["block"]}
+
+### TAPER
+{taper_mindset}
+{taper_block["block"]}
 
 ## CONDITIONING
 {conditioning_block}

--- a/mindset_module.py
+++ b/mindset_module.py
@@ -173,3 +173,18 @@ def get_mental_protocols(blocks: list) -> str:
         sections.append("\n".join(phase_lines))
 
     return "\n\n".join(sections)
+
+def get_phase_mindset_cues(blocks) -> dict:
+    """Return a short cue per phase based on top mental blocks."""
+    if isinstance(blocks, str):
+        blocks = [blocks]
+    blocks = blocks[:2] if blocks else ["generic"]
+
+    cues = {}
+    for phase in ["GPP", "SPP", "TAPER"]:
+        tips = []
+        for block in blocks:
+            tip = mindset_bank.get(phase, {}).get(block, mindset_bank[phase]["generic"])
+            tips.append(f"{block.title()}: {tip}")
+        cues[phase] = " | ".join(tips)
+    return cues

--- a/strength.py
+++ b/strength.py
@@ -21,7 +21,6 @@ try:
 except Exception:
     STYLE_EXERCISES = []
 
-# Mandatory exercises per tactical style
 STYLE_MANDATORY = {
     "brawler": ["Sledgehammer Slam", "Medicine Ball Slam"],
     "pressure fighter": ["Weighted Sled Push", "Jumping Lunge"],
@@ -52,18 +51,7 @@ def equipment_score_adjust(entry_equip, user_equipment, known_equipment):
 
 exercise_bank = json.loads(Path("exercise_bank.json").read_text())
 
-def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
-    """Create a strength training block for a single phase.
-
-    Args:
-        flags: Training context parameters.
-        weaknesses: List of athlete weaknesses to bias exercise selection.
-        mindset_cue: Short mindset habit or drill to append to the block.
-
-    Returns:
-        Dict with generated block text, session count, preferred tags and
-        chosen exercises.
-    """
+def generate_strength_block(*, flags: dict, weaknesses=None):
     phase = flags.get("phase", "GPP").upper()
     injuries = flags.get("injuries", [])
     fatigue = flags.get("fatigue", "low")
@@ -76,7 +64,6 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     num_strength_sessions = allocate_sessions(days_available).get("strength", 2)
     prev_exercises = flags.get("prev_exercises", [])
 
-    # Style and goal tags
     style_tag_map = {
         "brawler": ["compound", "posterior_chain", "power", "rate_of_force", "grip", "core"],
         "pressure fighter": ["conditioning", "core", "rate_of_force", "endurance", "mental_toughness", "anaerobic_alactic"],
@@ -89,51 +76,50 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     }
 
     goal_tag_map = {
-    "power": [
-        "explosive", "rate_of_force", "triple_extension", "horizontal_power",
-        "plyometric", "elastic", "lateral_power", "deadlift",
-        "ATP-PCr", "anaerobic_alactic", "speed_strength"
-    ],
-    "strength": [
-        "posterior_chain", "quad_dominant", "upper_body", "core", "pull", "hamstring",
-        "hip_dominant", "eccentric", "deadlift", "compound", "manual_resistance", "isometric"
-    ],
-    "endurance": [
-        "aerobic", "glycolytic", "anaerobic_lactic", "work_capacity", "mental_toughness",
-        "conditioning", "improvised", "volume_tolerance"
-    ],
-    "speed": [
-        "speed", "agility", "footwork", "reactive", "acceleration", "ATP-PCr", "anaerobic_alactic",
-        "visual_processing", "reactive_decision"
-    ],
-    "mobility": [
-        "mobility", "hip_dominant", "balance", "eccentric", "unilateral", "adductors",
-        "stability", "movement_quality", "range", "rehab_friendly"
-    ],
-    "grappling": [
-        "wrestling", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
-        "manual_resistance", "positioning"
-    ],
-    "striking": [
-        "striking", "boxing", "muay_thai", "shoulders", "rate_of_force",
-        "coordination", "visual_processing", "rhythm", "timing"
-    ],
-    "injury prevention": [
-        "recovery", "balance", "eccentric", "zero_impact", "parasympathetic",
-        "cns_freshness", "unilateral", "movement_quality", "stability", "neck"
-    ],
-    "mental resilience": [
-        "mental_toughness", "cognitive", "parasympathetic", "visual_processing",
-        "focus", "environmental", "pressure_tolerance"
-    ],
-    "skill refinement": [
-        "coordination", "skill", "footwork", "cognitive", "focus", "reactive", "decision_speed"
-    ]
-}
+        "power": [
+            "explosive", "rate_of_force", "triple_extension", "horizontal_power",
+            "plyometric", "elastic", "lateral_power", "deadlift",
+            "ATP-PCr", "anaerobic_alactic", "speed_strength"
+        ],
+        "strength": [
+            "posterior_chain", "quad_dominant", "upper_body", "core", "pull", "hamstring",
+            "hip_dominant", "eccentric", "deadlift", "compound", "manual_resistance", "isometric"
+        ],
+        "endurance": [
+            "aerobic", "glycolytic", "anaerobic_lactic", "work_capacity", "mental_toughness",
+            "conditioning", "improvised", "volume_tolerance"
+        ],
+        "speed": [
+            "speed", "agility", "footwork", "reactive", "acceleration", "ATP-PCr", "anaerobic_alactic",
+            "visual_processing", "reactive_decision"
+        ],
+        "mobility": [
+            "mobility", "hip_dominant", "balance", "eccentric", "unilateral", "adductors",
+            "stability", "movement_quality", "range", "rehab_friendly"
+        ],
+        "grappling": [
+            "wrestling", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
+            "manual_resistance", "positioning"
+        ],
+        "striking": [
+            "striking", "boxing", "muay_thai", "shoulders", "rate_of_force",
+            "coordination", "visual_processing", "rhythm", "timing"
+        ],
+        "injury prevention": [
+            "recovery", "balance", "eccentric", "zero_impact", "parasympathetic",
+            "cns_freshness", "unilateral", "movement_quality", "stability", "neck"
+        ],
+        "mental resilience": [
+            "mental_toughness", "cognitive", "parasympathetic", "visual_processing",
+            "focus", "environmental", "pressure_tolerance"
+        ],
+        "skill refinement": [
+            "coordination", "skill", "footwork", "cognitive", "focus", "reactive", "decision_speed"
+        ]
+    }
+
     style_tags = style_tag_map.get(style, [])
     goal_tags = [tag for g in goals for tag in goal_tag_map.get(g, [])]
-
-    # Equipment boost logic
     boosted_tools = phase_equipment_boost.get(phase.upper(), set())
 
     phase_tag_boost = {
@@ -335,8 +321,6 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     ]
     if fatigue_note:
         strength_output.append(f"**Adjustment:** {fatigue_note}")
-    if mindset_cue:
-        strength_output.append(f"**Mindset Cue:** {mindset_cue}")
 
     all_tags = []
     for ex in base_exercises:

--- a/strength.py
+++ b/strength.py
@@ -52,7 +52,18 @@ def equipment_score_adjust(entry_equip, user_equipment, known_equipment):
 
 exercise_bank = json.loads(Path("exercise_bank.json").read_text())
 
-def generate_strength_block(*, flags: dict, weaknesses=None):
+def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
+    """Create a strength training block for a single phase.
+
+    Args:
+        flags: Training context parameters.
+        weaknesses: List of athlete weaknesses to bias exercise selection.
+        mindset_cue: Short mindset habit or drill to append to the block.
+
+    Returns:
+        Dict with generated block text, session count, preferred tags and
+        chosen exercises.
+    """
     phase = flags.get("phase", "GPP").upper()
     injuries = flags.get("injuries", [])
     fatigue = flags.get("fatigue", "low")
@@ -324,6 +335,8 @@ def generate_strength_block(*, flags: dict, weaknesses=None):
     ]
     if fatigue_note:
         strength_output.append(f"**Adjustment:** {fatigue_note}")
+    if mindset_cue:
+        strength_output.append(f"**Mindset Cue:** {mindset_cue}")
 
     all_tags = []
     for ex in base_exercises:


### PR DESCRIPTION
## Summary
- restore prior prompt structure
- inject mindset cue per phase in strength block
- add global "MENTAL PERFORMANCE STRATEGY" section

## Testing
- `python -m py_compile mindset_module.py strength.py main.py`
- `python -m py_compile conditioning.py recovery.py nutrition.py training_context.py`


------
https://chatgpt.com/codex/tasks/task_e_684568a49a5c832eabeb21d1d6c26a52