### PR TITLE
Fix camp phase style ratios

### DIFF
--- a/main.py
+++ b/main.py
@@ -182,6 +182,8 @@ async def handle_submission(request: Request):
     raw_tech_style = fighting_style_technical.strip().lower()
     mapped_format = style_map.get(raw_tech_style, "mma")
     tactical_styles = normalize_list(fighting_style_tactical)
+    if stance.strip().lower() == "hybrid" and "hybrid" not in tactical_styles:
+        tactical_styles.append("hybrid")
 
     if isinstance(weeks_out, int):
         phase_weeks = calculate_phase_weeks(


### PR DESCRIPTION
## Summary
- refactor style rule logic in `calculate_phase_weeks`
- apply `SPP_CLINCH_RATIO` and `SPP_BOXING_RATIO` via helper
- add hybrid stance detection in main webhook

## Testing
- `python -m py_compile camp_phases.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6847f5c72234832e9ab2c6b57affcf63