### PR TITLE
Fix phase week allocation logic and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# UNLXCK GPT Webhook
+
+This repository generates fight camp programs using OpenAI prompts. The main script reads athlete data and calls `camp_phases.calculate_phase_weeks()` to break a camp into GPP, SPP, and taper phases.
+
+Recent updates fixed short-camp handling and ensured style-specific rules adjust the phase weeks correctly. The helper `_apply_style_rules()` is now used so tactical styles like "pressure fighter" can modify the week allocation after the base calculation.


### PR DESCRIPTION
## Summary
- refine `calculate_phase_weeks` to rebalance weeks and apply style rules
- document project usage and recent fixes in a new README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from camp_phases import calculate_phase_weeks
print(calculate_phase_weeks(8, 'boxing'))
print(calculate_phase_weeks(8, 'boxing', ['pressure fighter']))
print('1 week:', calculate_phase_weeks(1, 'boxing'))
print('2 week:', calculate_phase_weeks(2, 'boxing'))
print('3 week:', calculate_phase_weeks(3, 'boxing'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684827c03cfc832ebf5e25c99cef4ff8