### PR TITLE
Fix distance striker tags

### DIFF
--- a/notes/distance_striker_conditioning_bank.json
+++ b/notes/distance_striker_conditioning_bank.json
@@ -7,7 +7,7 @@
     "modality": "footwork",
     "duration": "3min work, 1min rest x 5 rounds",
     "intensity": "80% effort",
-    "tags": ["distance_fighter", "boxing", "kickboxing", "mma"],
+    "tags": ["distance_striker", "boxing", "kickboxing", "mma"],
     "notes": "Sharp pivots off cones, maintain stance while circling.",
     "equipment_note": "Set cones in diamond pattern"
   },
@@ -19,7 +19,7 @@
     "modality": "resisted footwork",
     "duration": "30s lateral steps, 30s rest x 8 rounds",
     "intensity": "70-80% effort",
-    "tags": ["distance_fighter", "boxing", "kickboxing", "mma"],
+    "tags": ["distance_striker", "boxing", "kickboxing", "mma"],
     "notes": "Ankle bands for defensive slide training.",
     "equipment_note": "Light resistance bands"
   },
@@ -31,7 +31,7 @@
     "modality": "backstep counters",
     "duration": "10 backstep jabs + 5 cross counters, 5 rounds",
     "intensity": "Explosive",
-    "tags": ["distance_fighter", "boxing", "kickboxing"],
+    "tags": ["distance_striker", "boxing", "kickboxing"],
     "notes": "Trains pull-counter mechanics under load.",
     "equipment_note": "5-10lb DBs for hand weight"
   },
@@ -43,7 +43,7 @@
     "modality": "angle striking",
     "duration": "3min rounds: 45° cuts after combos, 1min rest x 4",
     "intensity": "85% effort",
-    "tags": ["distance_fighter", "boxing", "mma"],
+    "tags": ["distance_striker", "boxing", "mma"],
     "notes": "Band-resisted shuffles to reinforce cutting angles.",
     "equipment_note": "Hip-height band anchor"
   },
@@ -55,7 +55,7 @@
     "modality": "range management",
     "duration": "20m sprints w/ med ball feints, 6 rounds",
     "intensity": "90% sprint effort",
-    "tags": ["distance_fighter", "kickboxing", "mma"],
+    "tags": ["distance_striker", "kickboxing", "mma"],
     "notes": "Sprint in/out of range, feinting level changes.",
     "equipment_note": "6-10kg med ball"
   },
@@ -67,7 +67,7 @@
     "modality": "precision endurance",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "Fast twitch focus",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "Band-resisted shoulders during bag work.",
     "equipment_note": "Light bands for delt fatigue"
   },
@@ -79,7 +79,7 @@
     "modality": "footwork + stamina",
     "duration": "30s ropes + 30s cone drills, 8 rounds",
     "intensity": "85% effort",
-    "tags": ["distance_fighter", "boxing", "kickboxing"],
+    "tags": ["distance_striker", "boxing", "kickboxing"],
     "notes": "Ropes fatigue arms before footwork precision.",
     "equipment_note": "1.5\" ropes, 5-cone star pattern"
   },
@@ -91,7 +91,7 @@
     "modality": "defensive backpedaling",
     "duration": "20m sled drags backward, 6 rounds",
     "intensity": "50% bodyweight load",
-    "tags": ["distance_fighter", "mma"],
+    "tags": ["distance_striker", "mma"],
     "notes": "Resisted movement to build defensive speed.",
     "equipment_note": "Low sled height for posture"
   },
@@ -103,7 +103,7 @@
     "modality": "lateral explosiveness",
     "duration": "10 KB swings (per side) + 5 lateral jumps, 5 rounds",
     "intensity": "Max power",
-    "tags": ["distance_fighter", "kickboxing", "mma"],
+    "tags": ["distance_striker", "kickboxing", "mma"],
     "notes": "Swings mimic check hook power.",
     "equipment_note": "16-24kg KB"
   },
@@ -115,7 +115,7 @@
     "modality": "shoulder endurance",
     "duration": "1min band-resisted jabs, 30s rest x 6",
     "intensity": "80% effort",
-    "tags": ["distance_fighter", "boxing", "mma"],
+    "tags": ["distance_striker", "boxing", "mma"],
     "notes": "Trains Philly shell/long guard stamina.",
     "equipment_note": "5lb DBs in non-jabbing hand"
   },
@@ -127,7 +127,7 @@
     "modality": "1-2 precision",
     "duration": "50 straight rights on bag, reset after each, 5 rounds",
     "intensity": "90% power",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "Emphasizes retraction and re-angle.",
     "equipment_note": "Bag at eye level"
   },
@@ -139,7 +139,7 @@
     "modality": "cage cutting",
     "duration": "3min rounds, 1min rest x 4",
     "intensity": "70% effort",
-    "tags": ["distance_fighter", "mma"],
+    "tags": ["distance_striker", "mma"],
     "notes": "45° exits off ladder into cone pivots.",
     "equipment_note": "Set cones at 8 angles"
   },
@@ -151,7 +151,7 @@
     "modality": "push kick defense",
     "duration": "20 resisted backsteps, 10 teep counters, 5 rounds",
     "intensity": "80% effort",
-    "tags": ["distance_fighter", "kickboxing", "mma"],
+    "tags": ["distance_striker", "kickboxing", "mma"],
     "notes": "Bands anchored at hips for resistance.",
     "equipment_note": "Heavy bands only"
   },
@@ -163,7 +163,7 @@
     "modality": "shoulder stamina",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "Fast twitch focus",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "1-2s only, reset stance after each combo.",
     "equipment_note": "High bag tension"
   },
@@ -175,7 +175,7 @@
     "modality": "slip-counter",
     "duration": "3min rounds: slip right → cross, 1min rest x 4",
     "intensity": "85% power",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "Band-resisted slips for defensive load.",
     "equipment_note": "Anchor bands at head height"
   },
@@ -187,7 +187,7 @@
     "modality": "rotational power",
     "duration": "5 landmine twists/side, 5 rounds",
     "intensity": "60% 1RM",
-    "tags": ["distance_fighter", "boxing", "mma"],
+    "tags": ["distance_striker", "boxing", "mma"],
     "notes": "Mimics cross/overhand torque.",
     "equipment_note": "Use bumper plates"
   },
@@ -199,7 +199,7 @@
     "modality": "step-in striking",
     "duration": "10 band-resisted step jabs, 5 rounds",
     "intensity": "80% speed",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "Bands force explosive entry/exit.",
     "equipment_note": "5lb DBs in rear hand"
   },
@@ -211,7 +211,7 @@
     "modality": "unpredictability",
     "duration": "3min rounds: random direction changes, 1min rest x 4",
     "intensity": "70% effort",
-    "tags": ["distance_fighter", "boxing", "kickboxing"],
+    "tags": ["distance_striker", "boxing", "kickboxing"],
     "notes": "No set pattern—coach calls direction.",
     "equipment_note": "Use 10ft ladder"
   },
@@ -223,7 +223,7 @@
     "modality": "exhausted precision",
     "duration": "30s max-speed punches → 30s defensive slides, 6 rounds",
     "intensity": "90% effort",
-    "tags": ["distance_fighter", "boxing"],
+    "tags": ["distance_striker", "boxing"],
     "notes": "Bands on ankles during bag work.",
     "equipment_note": "Light resistance only"
   },
@@ -235,7 +235,7 @@
     "modality": "endurance",
     "duration": "30s hangs, 30s rest x 8",
     "intensity": "70% effort",
-    "tags": ["distance_fighter", "mma"],
+    "tags": ["distance_striker", "mma"],
     "notes": "Towel grips simulate clinch fights.",
     "equipment_note": "2 towels for MMA transfer"
   }


### PR DESCRIPTION
## Summary
- correct `distance_fighter` typos to `distance_striker` in conditioning drills

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684897149a9c832e9dd34a4866b0ba54