### PR TITLE
Add scrambler style adjustment

### DIFF
--- a/camp_phases.py
+++ b/camp_phases.py
@@ -108,6 +108,7 @@ STYLE_ADJUSTMENTS = {
     "muay_thai": {"SPP": +0.03, "GPP": -0.03},
     "hybrid": {"SPP": +0.04, "TAPER": -0.04},
     "clinch fighter": {"GPP": +0.05, "SPP": -0.05},
+    "scrambler": {"GPP": +0.03, "TAPER": -0.03},
 }
 
 STYLE_RULES = {


### PR DESCRIPTION
## Summary
- adjust phase ratio defaults for scrambler style

## Testing
- `python -m py_compile camp_phases.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ca6031cc832e9f7d83b0b601ede8