### PR TITLE
Fix style exercise list terminator

### DIFF
--- a/style_specific_exercises
+++ b/style_specific_exercises
@@ -158,3 +158,5 @@ style_specific_exercises = [
         "type": "ballistic",
         "tags": ["explosive", "cognitive", "style_brawler"],
         "equipment": "medicine_ball"
+    }
+]


### PR DESCRIPTION
## Summary
- close missing brackets in style_specific_exercises

## Testing
- `python -m py_compile main.py training_context.py conditioning.py strength.py recovery.py nutrition.py injury_subs.py mindset_module.py camp_phases.py`


------
https://chatgpt.com/codex/tasks/task_e_6848d2071e14832e912b4a7e03b418a1