### PR TITLE
Add professional status phase adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This repository generates fight camp programs by combining local training modules. The main script reads athlete data, assembles strength, conditioning, recovery and other blocks, then exports the result directly to Google Docs.
 
 Recent updates removed the OpenAI dependency and now build plans entirely from the module outputs. Short-camp handling and style-specific rules still adjust the phase weeks correctly via the helper `_apply_style_rules()`.
+
+### Professional Status
+
+Setting the **Professional Status** field to `professional` shifts 5% of the camp length from GPP to SPP when the camp is at least four weeks long. GPP will never drop below 15% of total weeks.

--- a/camp_phases.py
+++ b/camp_phases.py
@@ -164,7 +164,10 @@ def _apply_style_rules(rules: dict, camp_length: int, weeks: dict) -> None:
             weeks["SPP"] = min_spp
             weeks["GPP"] = max(1, weeks["GPP"] - diff)
 def calculate_phase_weeks(
-    camp_length: int, sport: str, style: str | list[str] | None = None
+    camp_length: int,
+    sport: str,
+    style: str | list[str] | None = None,
+    status: str | None = None,
 ) -> dict:
     """Return weeks per phase for a fight camp.
 
@@ -202,6 +205,15 @@ def calculate_phase_weeks(
             ratios["SPP"] = max(ratios["SPP"], rules["SPP_CLINCH_RATIO"])
         if "GPP_MIN_PERCENT" in rules:
             ratios["GPP"] = max(ratios["GPP"], rules["GPP_MIN_PERCENT"])
+
+    # 3b. Professional adjustment: shift 5% from GPP to SPP
+    if status and status.strip().lower() == "professional" and camp_length >= 4:
+        ratios["SPP"] += 0.05
+        ratios["GPP"] -= 0.05
+        if ratios["GPP"] < 0.15:
+            diff = 0.15 - ratios["GPP"]
+            ratios["GPP"] = 0.15
+            ratios["SPP"] = max(0.05, ratios["SPP"] - diff)
 
     # 4. Re-normalize so GPP + SPP + TAPER == 1.0
     total = ratios["GPP"] + ratios["SPP"] + ratios["TAPER"]

--- a/main.py
+++ b/main.py
@@ -153,12 +153,14 @@ async def handle_submission(request: Request):
             weeks_out,
             mapped_format,
             tactical_styles,
+            status,
         )
     else:
         phase_weeks = calculate_phase_weeks(
             8,
             mapped_format,
             tactical_styles,
+            status,
         )
 
     # Core context


### PR DESCRIPTION
## Summary
- add a new `status` parameter to `calculate_phase_weeks`
- boost SPP by 5% and drop GPP by 5% for professional athletes when camp is four weeks or longer, ensuring GPP never falls below 15%
- pass professional status from the form through `main.py`
- document the new Professional Status option in README

## Testing
- `python -m py_compile camp_phases.py main.py training_context.py conditioning.py strength.py recovery.py nutrition.py injury_subs.py mindset_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68493bccdeb4832e8167655620532f22