### PR TITLE
Update taper filtering

### DIFF
--- a/conditioning.py
+++ b/conditioning.py
@@ -16,9 +16,19 @@ style_tag_map = {
 
 # Extra explosive or high-load tags to avoid during TAPER when fatigue isn't low
 TAPER_AVOID_TAGS = {
-    "plyometric", "rate_of_force", "contrast_pairing", "horizontal_power",
-    "triple_extension", "overhead", "elastic", "compound", "mental_toughness",
-    "work_capacity", "eccentric", "footwork",
+    "plyometric",
+    "rate_of_force",
+    "contrast_pairing",
+    "horizontal_power",
+    "triple_extension",
+    "overhead",
+    "elastic",
+    "compound",
+    "mental_toughness",
+    "work_capacity",
+    "eccentric",
+    "footwork",
+    "lunge_pattern",
 }
 
 # Goal tags

--- a/strength.py
+++ b/strength.py
@@ -136,7 +136,23 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
 
     weighted_exercises = []
     taper_allowed = {"neural_primer", "speed", "cluster", "explosive", "low_impact", "reactive", "rehab_friendly"}
-    taper_banned = {"eccentric", "compound", "posterior_chain", "high_volume", "barbell", "trap_bar"}
+    taper_banned = {
+        "eccentric",
+        "lunge_pattern",
+        "compound",
+        "horizontal_power",
+        "triple_extension",
+        "overhead",
+        "contrast_pairing",
+        "rate_of_force",
+        "plyometric",
+        "elastic",
+        "mental_toughness",
+        "posterior_chain",
+        "high_volume",
+        "barbell",
+        "trap_bar",
+    }
 
     for ex in exercise_bank:
         tags = ex.get("tags", [])


### PR DESCRIPTION
## Summary
- block more tags during taper in strength module
- add lunge_pattern to taper avoid list for conditioning

## Testing
- `python -m py_compile conditioning.py strength.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6848d9236a98832eaa2b0a6a99c1bd16