### PR TITLE
Improve pro camp logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ Recent updates removed the OpenAI dependency and now build plans entirely from t
 
 ### Professional Status
 
-Setting the **Professional Status** field to `professional` shifts 5% of the camp length from GPP to SPP when the camp is at least four weeks long. GPP will never drop below 15% of total weeks.
+Setting the **Professional Status** field to `pro` or `professional` adjusts the camp ratios when the camp is four weeks or longer. The shift from GPP to SPP depends on fatigue, weight cutting and mindset:
+
+- **Clean athlete** – low fatigue, no weight cut and an approved mindset block ("confidence" or "generic"): **+10%** SPP
+- **Reliable athlete** – low/moderate fatigue, cutting ≤5% bodyweight and no burnout/overthinking blocks: **+7.5%** SPP
+- **Normal pro** – all other cases: **+5%** SPP
+
+GPP is reduced by the same amount but never drops below 15% of the total camp.
 
 ### Module Weightings & Scoring
 

--- a/camp_phases.py
+++ b/camp_phases.py
@@ -128,6 +128,10 @@ STYLE_RULES = {
     },
 }
 
+# Mental blocks that still allow a professional athlete to be
+# classified as "clean" for Tier 3 adjustments.
+APPROVED_TIER3_BLOCKS = {"confidence", "generic"}
+
 
 def _normalize_styles(style: str | list[str] | None) -> list[str]:
     if style is None:
@@ -168,12 +172,19 @@ def calculate_phase_weeks(
     sport: str,
     style: str | list[str] | None = None,
     status: str | None = None,
+    fatigue: str | None = None,
+    weight_cut_risk: bool | None = None,
+    mental_block: str | list[str] | None = None,
+    weight_cut_pct: float | None = None,
 ) -> dict:
     """Return weeks per phase for a fight camp.
 
     The calculation prioritizes the base ratios for 1–16 week camps, then
     applies any style adjustments followed by min/max rules.  Output weeks
-    always sum to ``camp_length`` and taper is limited to two weeks.
+    always sum to ``camp_length`` and taper is limited to two weeks.  If the
+    athlete is ``pro``/``professional`` and the camp is at least four weeks
+    long, GPP time is shifted to SPP based on fatigue, weight cut and mental
+    block state.
     """
 
     # 1. Clamp camp_length and fetch base ratios
@@ -206,10 +217,24 @@ def calculate_phase_weeks(
         if "GPP_MIN_PERCENT" in rules:
             ratios["GPP"] = max(ratios["GPP"], rules["GPP_MIN_PERCENT"])
 
-    # 3b. Professional adjustment: shift 5% from GPP to SPP
-    if status and status.strip().lower() == "professional" and camp_length >= 4:
-        ratios["SPP"] += 0.05
-        ratios["GPP"] -= 0.05
+    # 3b. Professional adjustment based on fatigue, cut and mindset
+    if status and status.strip().lower() in {"professional", "pro"} and camp_length >= 4:
+        mb = mental_block[0] if isinstance(mental_block, list) else mental_block
+        mb = mb.lower() if isinstance(mb, str) else ""
+        fat = (fatigue or "").strip().lower()
+        cut_pct = weight_cut_pct if weight_cut_pct is not None else 0.0
+        cut_flag = bool(weight_cut_risk)
+
+        if fat == "low" and not cut_flag and mb in APPROVED_TIER3_BLOCKS:
+            ratios["SPP"] += 0.10
+            ratios["GPP"] -= 0.10
+        elif fat in ["low", "moderate"] and cut_pct <= 5 and mb not in ["burnout", "overthinking"]:
+            ratios["SPP"] += 0.075
+            ratios["GPP"] -= 0.075
+        else:
+            ratios["SPP"] += 0.05
+            ratios["GPP"] -= 0.05
+
         if ratios["GPP"] < 0.15:
             diff = 0.15 - ratios["GPP"]
             ratios["GPP"] = 0.15


### PR DESCRIPTION
## Summary
- refine README to explain pro ratios using fatigue, weight cut, and mindset
- extend `calculate_phase_weeks` with fatigue, cut, and mindset parameters
- adjust pro ratio logic accordingly
- pass the new arguments from `main.py`
- clarify clean-pro mental blocks and expose constant `APPROVED_TIER3_BLOCKS`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849431390b4832e9e4102b7aac79ab5