### PR TITLE
Handle training frequency separately from available days

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Keyword counts determine the top mental blocks. The two highest scoring blocks f
 
 **Training context** (`training_context.py`)
 
-The helper `allocate_sessions()` assigns weekly sessions based on available days:
+The helper `allocate_sessions()` assigns weekly sessions based on the
+numeric **training frequency** it receives:
 
 ```
 ≤3 days  → {'strength': 1, 'conditioning': 1, 'recovery': 1}
@@ -59,3 +60,10 @@ The helper `allocate_sessions()` assigns weekly sessions based on available days
 5 days   → {'strength': 2, 'conditioning': 2, 'recovery': 1}
 >5 days  → {'strength': 3, 'conditioning': 2, 'recovery': 1}
 ```
+
+`Weekly Training Frequency` is the number of sessions the athlete plans to
+complete each week. The `Time Availability for Training` field simply lists
+which days are open. Frequency does **not** automatically equal the count of
+available days—a fighter might have seven days free but only train five times
+per week. The program schedules sessions based on the provided frequency and
+assigns them to the supplied training days.

--- a/conditioning.py
+++ b/conditioning.py
@@ -131,7 +131,7 @@ def generate_conditioning_block(flags):
     technical = flags.get("style_technical", [])
     goals = flags.get("key_goals", [])
     weaknesses = flags.get("weaknesses", [])
-    days_available = flags.get("days_available", 3)
+    training_frequency = flags.get("training_frequency", flags.get("days_available", 3))
     equipment_access = normalize_equipment_list(flags.get("equipment", []))
 
     # Handle multiple technical styles
@@ -299,11 +299,11 @@ def generate_conditioning_block(flags):
         for drills in style_lists.values():
             drills.sort(key=lambda x: x[1], reverse=True)
 
-    if days_available >= 6:
+    if training_frequency >= 6:
         num_conditioning_sessions = 3
-    elif days_available >= 4:
+    elif training_frequency >= 4:
         num_conditioning_sessions = 2
-    elif days_available >= 2:
+    elif training_frequency >= 2:
         num_conditioning_sessions = 1
     else:
         num_conditioning_sessions = 0

--- a/strength.py
+++ b/strength.py
@@ -65,8 +65,10 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
         style_list = []
     goals = flags.get("key_goals", [])
     training_days = flags.get("training_days", [])
-    days_available = flags.get("days_available", len(training_days))
-    num_strength_sessions = allocate_sessions(days_available).get("strength", 2)
+    training_frequency = flags.get(
+        "training_frequency", flags.get("days_available", len(training_days))
+    )
+    num_strength_sessions = allocate_sessions(training_frequency).get("strength", 2)
     prev_exercises = flags.get("prev_exercises", [])
 
     style_tag_map = {

--- a/training_context.py
+++ b/training_context.py
@@ -21,12 +21,13 @@ known_equipment = [
     "elliptical", "bodyweight", "med_balls", "battle_rope", "kettlebells"
 ]
 
-def allocate_sessions(days_available: int) -> dict:
-    if days_available <= 3:
+def allocate_sessions(training_frequency: int) -> dict:
+    """Return weekly session counts based on training frequency."""
+    if training_frequency <= 3:
         return {'strength': 1, 'conditioning': 1, 'recovery': 1}
-    elif days_available == 4:
+    elif training_frequency == 4:
         return {'strength': 2, 'conditioning': 1, 'recovery': 1}
-    elif days_available == 5:
+    elif training_frequency == 5:
         return {'strength': 2, 'conditioning': 2, 'recovery': 1}
     else:
         return {'strength': 3, 'conditioning': 2, 'recovery': 1}


### PR DESCRIPTION
## Summary
- clarify that `allocate_sessions()` uses weekly training frequency
- rename function parameter for clarity

## Testing
- `python -m py_compile main.py strength.py conditioning.py training_context.py`

------
https://chatgpt.com/codex/tasks/task_e_684954e3f398832eac13731ab7eccc08