### PR TITLE
Add format, phase, and style conditioning docs

### DIFF
--- a/notes/cheat_sheet.md
+++ b/notes/cheat_sheet.md
@@ -1,0 +1,144 @@
+# Tag and Scoring Cheat Sheet
+
+This document is a quick reference for the tags used throughout the fight camp builder and how the program scores and selects exercises. It is written in plain language so that even a teenager can follow along.
+
+## What Are Tags?
+
+Tags are short keywords attached to every drill or exercise. They describe what the movement trains (for example `core` or `explosive`) or who it suits (like `wrestling` or `muay_thai`). When the program builds your plan it looks at your goals, weaknesses and fighting style and then picks moves with the best matching tags.
+
+Below is a list of all tags found in the banks. The descriptions are brief so you have a general idea of what each tag means.
+
+- **ATP-PCr** – general tag for ATP-PCr.
+- **acceleration** – general tag for acceleration.
+- **adductors** – general tag for adductors.
+- **aerobic** – develops endurance.
+- **agility** – boosts agility.
+- **anaerobic_alactic** – develops endurance.
+- **anti_rotation** – general tag for anti rotation.
+- **arm_dominant** – general tag for arm dominant.
+- **athletic** – general tag for athletic.
+- **balance** – challenges balance.
+- **bjj** – grappling related.
+- **boxing** – striking specific.
+- **clinch** – general tag for clinch.
+- **cns_freshness** – general tag for cns freshness.
+- **cognitive** – adds decision making or brain work.
+- **compound** – general tag for compound.
+- **conditioning** – improves conditioning.
+- **contrast_pairing** – general tag for contrast pairing.
+- **coordination** – general tag for coordination.
+- **core** – targets the core.
+- **deadlift** – general tag for deadlift.
+- **eccentric** – general tag for eccentric.
+- **elastic** – general tag for elastic.
+- **endurance** – develops endurance.
+- **environmental** – general tag for environmental.
+- **explosive** – general tag for explosive.
+- **footwork** – general tag for footwork.
+- **glycolytic** – trains high intensity energy systems.
+- **grip** – strengthens grip.
+- **hamstring** – general tag for hamstring.
+- **hip_dominant** – targets posterior chain.
+- **horizontal_power** – builds power or explosiveness.
+- **improvised** – general tag for improvised.
+- **intensity** – internal use label.
+- **jump_rope** – general tag for jump rope.
+- **kettlebell** – general tag for kettlebell.
+- **lateral_power** – builds power or explosiveness.
+- **low_cns** – general tag for low cns.
+- **low_impact** – general tag for low impact.
+- **low_volume** – general tag for low volume.
+- **lunge_pattern** – general tag for lunge pattern.
+- **mental_toughness** – general tag for mental toughness.
+- **mma** – grappling related.
+- **mobility** – improves joint mobility.
+- **muay_thai** – striking specific.
+- **overhead** – general tag for overhead.
+- **parasympathetic** – promotes recovery and relaxation.
+- **phases** – internal use label.
+- **plyometric** – uses plyometric movements.
+- **posterior_chain** – targets posterior chain.
+- **pull** – general tag for pull.
+- **quad_dominant** – focuses on quads.
+- **rate_of_force** – general tag for rate of force.
+- **reactive** – improves reaction speed.
+- **recovery** – helps recovery.
+- **rehab_friendly** – general tag for rehab friendly.
+- **rotational** – general tag for rotational.
+- **sharpness** – general tag for sharpness.
+- **shoulders** – general tag for shoulders.
+- **skill** – general tag for skill.
+- **sled** – general tag for sled.
+- **speed** – general tag for speed.
+- **striking** – striking specific.
+- **system** – internal use label.
+- **tags** – internal use label.
+- **top_control** – general tag for top control.
+- **transition** – general tag for transition.
+- **triphasic** – general tag for triphasic.
+- **triple_extension** – general tag for triple extension.
+- **unilateral** – works one side at a time.
+- **upper_body** – upper body work.
+- **visual_processing** – trains eyes and coordination.
+- **work_capacity** – general tag for work capacity.
+- **wrestling** – grappling related.
+- **zero_impact** – general tag for zero impact.
+
+## Scoring Basics
+
+Every module looks at how many of its tags match your goals, weaknesses and fighting style. More matches mean a higher score. Exercises with the best scores get picked first. Here is a simplified look at the weighting system from the code:
+
+### Strength Module
+- Weakness tag match: **+0.6** each
+- Goal tag match: **+0.5** each
+- Style tag match: **+0.3** each
+- Two style tags together: **+0.2** bonus
+- Three or more style tags: **+0.1** bonus
+- Three total matches (goals, weaknesses or style): **+0.2** bonus
+- Phase tag match (GPP/SPP/TAPER): **+0.4** each
+- Fatigue penalty: **-0.35** (moderate) or **-0.75** (high)
+- Missing required equipment: exercise is skipped
+- Rehab exercise penalty: **-0.5** in GPP, **-1.0** in SPP, **-0.75** in TAPER
+
+### Conditioning Module
+- Weakness tag match: **+2.5** each (max two)
+- Goal tag match: **+2.0** each (max two)
+- Style tag match: **+1.0** each (max two)
+- Fight format tag: **+1.0** (max one)
+- Energy system multiplier from `format_energy_weights.json`
+- High CNS drills: **-1.0** or **-2.0** penalty if you're fatigued
+- Style‑specific drills: **+3.0** for style, **+1.5** for phase, **+1.0** for matching energy system and **+1.0** if you have the right equipment
+
+### Mindset and Phase Calculation
+- Mindset keywords are counted and the top two become your focus cues
+- Phase weeks come from `BASE_PHASE_RATIOS` with style tweaks. Pros shift **5%** from GPP to SPP and taper never lasts more than two weeks
+
+## How Sessions Are Scheduled
+
+The helper `allocate_sessions()` in `training_context.py` decides how many strength, conditioning and recovery days you get each week. It only cares about your chosen **training frequency**:
+
+```
+≤3 days  → {'strength': 1, 'conditioning': 1, 'recovery': 1}
+4 days   → {'strength': 2, 'conditioning': 1, 'recovery': 1}
+5 days   → {'strength': 2, 'conditioning': 2, 'recovery': 1}
+>5 days  → {'strength': 3, 'conditioning': 2, 'recovery': 1}
+```
+
+The days you actually have available just tell the program which slots to fill. If you list seven free days but pick a frequency of five, you'll only get five sessions.
+
+
+## Format Templates
+
+The file `format_round_templates.json` defines each sport's round and rest times so drills match MMA, boxing, kickboxing or Muay Thai rules. `format_energy_weights.json` sets how much each energy system matters for those formats.
+
+## Base Phase Ratios
+
+`BASE_PHASE_RATIOS` in `camp_phases.py` lays out how much of a camp is spent in each phase (GPP, SPP and TAPER) for camps from one to sixteen weeks. The program tweaks these percentages for your fighting style and never lets taper exceed two weeks. Pros shift about five percent of GPP over to SPP when the camp is four weeks or longer.
+
+## Style Conditioning Bank
+
+`style_conditioning_bank.json` holds extra conditioning drills tailored to tactical styles like pressure fighter or counter striker. During GPP about 20% of your conditioning comes from this bank, in SPP it's 60% and in TAPER only 5%. Each drill earns **+3.0** if it matches your style tags plus **+1.5** if it's designed for the current phase, **+1.0** if it trains the right energy system and **+1.0** if you have the needed equipment.
+
+## Tactical Style Scoring
+
+General conditioning drills give **+1.0** per matching style tag (up to two). Style-specific drills from the bank receive the bigger bonuses listed above so matching your tactical style strongly steers which exercises are chosen.


### PR DESCRIPTION
## Summary
- update notes with format JSON info and energy weights
- outline base phase ratios and pro adjustment
- describe style conditioning bank and bonuses for matching tactical style

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849f0546e84832e99c54d684ab4ae88