### PR TITLE
Update session allocation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,39 @@ Keyword counts determine the top mental blocks. The two highest scoring blocks f
 
 **Training context** (`training_context.py`)
 
-The helper `allocate_sessions()` assigns weekly sessions based on the
-numeric **training frequency** it receives:
+The helper `allocate_sessions()` now takes a phase and returns the split for
+strength, conditioning and recovery. The schedule adapts across phases:
 
 ```
-≤3 days  → {'strength': 1, 'conditioning': 1, 'recovery': 1}
-4 days   → {'strength': 2, 'conditioning': 1, 'recovery': 1}
-5 days   → {'strength': 2, 'conditioning': 2, 'recovery': 1}
->5 days  → {'strength': 3, 'conditioning': 2, 'recovery': 1}
+1 session/week
+  GPP   → 1 Strength
+  SPP   → 1 Conditioning
+  Taper → 1 Conditioning
+
+2 sessions/week
+  GPP   → 1 Strength, 1 Conditioning
+  SPP   → 1 Strength, 1 Conditioning
+  Taper → 1 Conditioning, 1 Recovery
+
+3 sessions/week
+  GPP   → 1 Strength, 1 Conditioning, 1 Recovery
+  SPP   → 1 Strength, 2 Conditioning
+  Taper → 1 Strength, 1 Conditioning, 1 Recovery
+
+4 sessions/week
+  GPP   → 2 Strength, 1 Conditioning, 1 Recovery
+  SPP   → 1 Strength, 2 Conditioning, 1 Recovery
+  Taper → 1 Strength, 1 Conditioning, 2 Recovery
+
+5 sessions/week
+  GPP   → 2 Strength, 2 Conditioning, 1 Recovery
+  SPP   → 2 Strength, 2 Conditioning, 1 Recovery
+  Taper → 1 Strength, 1 Conditioning, 3 Recovery
+
+6 sessions/week
+  GPP   → 2 Strength, 3 Conditioning, 1 Recovery
+  SPP   → 2 Strength, 3 Conditioning, 1 Recovery
+  Taper → 1 Strength, 1 Conditioning, 4 Recovery
 ```
 
 `Weekly Training Frequency` is the number of sessions the athlete plans to

--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -295,14 +295,9 @@ def generate_conditioning_block(flags):
         for drills in style_lists.values():
             drills.sort(key=lambda x: x[1], reverse=True)
 
-    if training_frequency >= 6:
-        num_conditioning_sessions = 3
-    elif training_frequency >= 4:
-        num_conditioning_sessions = 2
-    elif training_frequency >= 2:
-        num_conditioning_sessions = 1
-    else:
-        num_conditioning_sessions = 0
+    num_conditioning_sessions = allocate_sessions(training_frequency, phase).get(
+        "conditioning", 0
+    )
 
     # Use 8 drills per detected conditioning session
     total_drills = 8 * num_conditioning_sessions
@@ -375,7 +370,6 @@ def generate_conditioning_block(flags):
         return None
 
     if phase.upper() == "TAPER":
-        total_drills = min(total_drills, 3)
         style_list = [s.lower() for s in style] if isinstance(style, list) else [style.lower()]
         combined_focus = [w.lower() for w in weaknesses] + [g.lower() for g in goals]
         allow_aerobic = any(k in combined_focus for k in ["conditioning", "endurance"])

--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -125,7 +125,7 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     training_frequency = flags.get(
         "training_frequency", flags.get("days_available", len(training_days))
     )
-    num_strength_sessions = allocate_sessions(training_frequency).get("strength", 2)
+    num_strength_sessions = allocate_sessions(training_frequency, phase).get("strength", 2)
     prev_exercises = flags.get("prev_exercises", [])
 
     style_tag_map = {

--- a/fightcamp/training_context.py
+++ b/fightcamp/training_context.py
@@ -21,13 +21,42 @@ known_equipment = [
     "elliptical", "bodyweight", "med_balls", "battle_rope", "kettlebells"
 ]
 
-def allocate_sessions(training_frequency: int) -> dict:
-    """Return weekly session counts based on training frequency."""
-    if training_frequency <= 3:
-        return {'strength': 1, 'conditioning': 1, 'recovery': 1}
-    elif training_frequency == 4:
-        return {'strength': 2, 'conditioning': 1, 'recovery': 1}
-    elif training_frequency == 5:
-        return {'strength': 2, 'conditioning': 2, 'recovery': 1}
-    else:
-        return {'strength': 3, 'conditioning': 2, 'recovery': 1}
+def allocate_sessions(training_frequency: int, phase: str = "GPP") -> dict:
+    """Return weekly session counts based on frequency and phase."""
+    freq = max(1, min(int(training_frequency), 6))
+    phase = phase.upper()
+
+    plan = {
+        1: {
+            "GPP": {"strength": 1, "conditioning": 0, "recovery": 0},
+            "SPP": {"strength": 0, "conditioning": 1, "recovery": 0},
+            "TAPER": {"strength": 0, "conditioning": 1, "recovery": 0},
+        },
+        2: {
+            "GPP": {"strength": 1, "conditioning": 1, "recovery": 0},
+            "SPP": {"strength": 1, "conditioning": 1, "recovery": 0},
+            "TAPER": {"strength": 0, "conditioning": 1, "recovery": 1},
+        },
+        3: {
+            "GPP": {"strength": 1, "conditioning": 1, "recovery": 1},
+            "SPP": {"strength": 1, "conditioning": 2, "recovery": 0},
+            "TAPER": {"strength": 1, "conditioning": 1, "recovery": 1},
+        },
+        4: {
+            "GPP": {"strength": 2, "conditioning": 1, "recovery": 1},
+            "SPP": {"strength": 1, "conditioning": 2, "recovery": 1},
+            "TAPER": {"strength": 1, "conditioning": 1, "recovery": 2},
+        },
+        5: {
+            "GPP": {"strength": 2, "conditioning": 2, "recovery": 1},
+            "SPP": {"strength": 2, "conditioning": 2, "recovery": 1},
+            "TAPER": {"strength": 1, "conditioning": 1, "recovery": 3},
+        },
+        6: {
+            "GPP": {"strength": 2, "conditioning": 3, "recovery": 1},
+            "SPP": {"strength": 2, "conditioning": 3, "recovery": 1},
+            "TAPER": {"strength": 1, "conditioning": 1, "recovery": 4},
+        },
+    }
+
+    return plan.get(freq, plan[6]).get(phase, {"strength": 1, "conditioning": 1, "recovery": 1})

--- a/notes/cheat_sheet.md
+++ b/notes/cheat_sheet.md
@@ -115,13 +115,17 @@ Every module looks at how many of its tags match your goals, weaknesses and figh
 
 ## How Sessions Are Scheduled
 
-The helper `allocate_sessions()` in `training_context.py` decides how many strength, conditioning and recovery days you get each week. It only cares about your chosen **training frequency**:
+The helper `allocate_sessions()` in `training_context.py` now uses both the
+weekly training frequency **and** the phase to return a split. Below is the new
+schedule (Strength : Conditioning : Recovery):
 
 ```
-≤3 days  → {'strength': 1, 'conditioning': 1, 'recovery': 1}
-4 days   → {'strength': 2, 'conditioning': 1, 'recovery': 1}
-5 days   → {'strength': 2, 'conditioning': 2, 'recovery': 1}
->5 days  → {'strength': 3, 'conditioning': 2, 'recovery': 1}
+1 day  → GPP 1:0:0 | SPP 0:1:0 | Taper 0:1:0
+2 days → GPP 1:1:0 | SPP 1:1:0 | Taper 0:1:1
+3 days → GPP 1:1:1 | SPP 1:2:0 | Taper 1:1:1
+4 days → GPP 2:1:1 | SPP 1:2:1 | Taper 1:1:2
+5 days → GPP 2:2:1 | SPP 2:2:1 | Taper 1:1:3
+6 days → GPP 2:3:1 | SPP 2:3:1 | Taper 1:1:4
 ```
 
 The days you actually have available just tell the program which slots to fill. If you list seven free days but pick a frequency of five, you'll only get five sessions.


### PR DESCRIPTION
## Summary
- add phase-aware session allocation
- share allocate_sessions between conditioning and strength
- remove Taper drill cap in conditioning
- document new allocation rules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849f633aecc832ebfe95cf3a92b083e