### PR TITLE
Implement phase-based exercise counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ which days are open. Frequency does **not** automatically equal the count of
 available days—a fighter might have seven days free but only train five times
 per week. The program schedules sessions based on the provided frequency and
 assigns them to the supplied training days.
+
+The function `calculate_exercise_numbers()` expands on this by converting the
+weekly session split into actual exercise counts.  Strength days output `7`,
+`6` or `4` exercises per session in `GPP`, `SPP` and `TAPER` respectively while
+conditioning days use `4`, `3` and `2`.  Recovery is implied by days without
+strength or conditioning work.

--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -1,6 +1,10 @@
 import json
 from pathlib import Path
-from .training_context import allocate_sessions, normalize_equipment_list
+from .training_context import (
+    allocate_sessions,
+    normalize_equipment_list,
+    calculate_exercise_numbers,
+)
 
 # Map for tactical styles
 style_tag_map = {
@@ -298,9 +302,10 @@ def generate_conditioning_block(flags):
     num_conditioning_sessions = allocate_sessions(training_frequency, phase).get(
         "conditioning", 0
     )
+    exercise_counts = calculate_exercise_numbers(training_frequency, phase)
 
-    # Use 8 drills per detected conditioning session
-    total_drills = 8 * num_conditioning_sessions
+    # Use recommended drill count based on phase multipliers
+    total_drills = exercise_counts.get("conditioning", 0)
 
     system_quota = {
         k: max(1 if v > 0 else 0, round(total_drills * v))
@@ -476,6 +481,8 @@ def generate_conditioning_block(flags):
             if d.get("equipment_note"):
                 output_lines.append(f"- notes: {d['equipment_note']}")
             output_lines.append(f"  • ⚠️ Red Flags: {d.get('red_flags', 'None')}")
+
+    output_lines.append(f"**Total Drills:** {total_drills}")
 
     if fatigue == "high":
         output_lines.append("\n⚠️ High fatigue detected – conditioning volume reduced.")

--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -3,7 +3,12 @@ import json
 import ast
 import random
 from .injury_subs import injury_subs
-from .training_context import normalize_equipment_list, known_equipment, allocate_sessions
+from .training_context import (
+    normalize_equipment_list,
+    known_equipment,
+    allocate_sessions,
+    calculate_exercise_numbers,
+)
 
 # Optional equipment boosts by training phase
 phase_equipment_boost = {
@@ -126,6 +131,8 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
         "training_frequency", flags.get("days_available", len(training_days))
     )
     num_strength_sessions = allocate_sessions(training_frequency, phase).get("strength", 2)
+    exercise_counts = calculate_exercise_numbers(training_frequency, phase)
+    target_exercises = exercise_counts.get("strength", 0)
     prev_exercises = flags.get("prev_exercises", [])
 
     style_tag_map = {
@@ -256,8 +263,7 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     days_count = len(training_days) if isinstance(training_days, list) else training_days
     if not isinstance(days_count, int):
         days_count = 3
-    # Use 8 drills per detected strength session
-    target_exercises = 8 * num_strength_sessions
+    # Target exercise count determined by phase multipliers
 
     if len(weighted_exercises) < target_exercises:
         fallback_exercises = []
@@ -384,7 +390,8 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
         f"**Primary Focus:** {focus}",
         "**Top Exercises:**",
     ] + [f"- {ex['name']}" for ex in base_exercises] + [
-        f"**Prescription:** {base_block}"
+        f"**Prescription:** {base_block}",
+        f"**Total Exercises:** {target_exercises}",
     ]
     if mindset_cue:
         strength_output.append(f"**Mindset Cue:** {mindset_cue}")

--- a/fightcamp/training_context.py
+++ b/fightcamp/training_context.py
@@ -60,3 +60,25 @@ def allocate_sessions(training_frequency: int, phase: str = "GPP") -> dict:
     }
 
     return plan.get(freq, plan[6]).get(phase, {"strength": 1, "conditioning": 1, "recovery": 1})
+
+
+def calculate_exercise_numbers(training_frequency: int, phase: str) -> dict:
+    """Return recommended exercise counts for each block type.
+
+    The result multiplies allocated session counts from ``allocate_sessions`` by
+    phase-specific exercise targets. Recovery days are implied by sessions not
+    scheduled for strength or conditioning.
+    """
+
+    sessions = allocate_sessions(training_frequency, phase)
+    phase = phase.upper()
+
+    strength_per_day = {"GPP": 7, "SPP": 6, "TAPER": 4}
+    conditioning_per_day = {"GPP": 4, "SPP": 3, "TAPER": 2}
+
+    return {
+        "strength": strength_per_day.get(phase, 0) * sessions.get("strength", 0),
+        "conditioning": conditioning_per_day.get(phase, 0) * sessions.get(
+            "conditioning", 0
+        ),
+    }


### PR DESCRIPTION
## Summary
- centralize exercise count logic with `calculate_exercise_numbers`
- use new counts in strength and conditioning modules
- show total exercises/drills in module outputs
- document the helper in README

## Testing
- `python -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6849ff62c074832e8ef700ae25dfeb99