### PR TITLE
Add style adjustment cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,22 @@ The style-match score never changes the bank ratio above—it just sorts the opt
 
 **Phase calculation** (`camp_phases.py`)
 
-Phase weeks come from `BASE_PHASE_RATIOS` with style adjustments. Professional athletes shift 5% from GPP to SPP. Ratios are rebalanced so the weeks always sum to the camp length and taper is capped at two weeks.
+Phase weeks come from `BASE_PHASE_RATIOS` with style adjustments. Professional athletes shift 5% from GPP to SPP. Ratios are rebalanced so the weeks always sum to the camp length and taper is capped at two weeks. When multiple styles move the same phase in one direction, the combined adjustment is capped at **7%**. This threshold is just above the largest single style shift (6%), allowing two minor adjustments to stack while avoiding extreme swings.
+
+### Style-Specific Phase Rules
+
+Certain tactical styles impose hard minimums or maximums on the camp phases. These rules come from `STYLE_RULES` in `camp_phases.py` and are enforced both when the ratios are first calculated and again after the weeks are rounded:
+
+- **Pressure fighter**
+  - `SPP_MIN_PERCENT: 0.45` – at least 45% of the schedule must be SPP. Weeks are pulled from GPP if needed.
+  - `MAX_TAPER: 0.10` – taper can be no more than 10% of the camp. Excess taper weeks go back into SPP.
+- **Clinch fighter**
+  - `TAPER_MAX_DAYS: 9` – taper tops out at nine days (roughly 1–1.5 weeks). Extra days shift to SPP.
+  - `SPP_CLINCH_RATIO: 0.40` – requires at least 40% of the camp in SPP.
+- **Grappler**
+  - `GPP_MIN_PERCENT: 0.35` – guarantees at least 35% of the camp in GPP. SPP is reduced if necessary.
+
+These constraints ensure fighters with those styles emphasize the most relevant phases even after other adjustments.
 
 **Mindset module** (`mindset_module.py`)
 

--- a/fightcamp/camp_phases.py
+++ b/fightcamp/camp_phases.py
@@ -114,6 +114,11 @@ STYLE_ADJUSTMENTS = {
     "scrambler": {"GPP": +0.03, "TAPER": -0.03},
 }
 
+# Cap for combined deltas when multiple styles push the same phase.
+# Individual style tweaks range from 3% to 6%, so a 7% ceiling lets a
+# couple small shifts stack while preventing outsized jumps.
+STYLE_ADJUSTMENT_CAP = 0.07
+
 STYLE_RULES = {
     "pressure fighter": {
         "SPP_MIN_PERCENT": 0.45,
@@ -188,12 +193,21 @@ def calculate_phase_weeks(
     closest = min(BASE_PHASE_RATIOS.keys(), key=lambda x: abs(x - camp_length))
     ratios = BASE_PHASE_RATIOS[closest][sport].copy()
 
-    # 2. Apply style adjustments
+    # 2. Apply style adjustments with cap when multiple styles stack
+    accumulated = {"GPP": 0.0, "SPP": 0.0, "TAPER": 0.0}
     for s in _normalize_styles(style):
         if s in STYLE_ADJUSTMENTS:
             for phase, delta in STYLE_ADJUSTMENTS[s].items():
-                if phase in ratios:
-                    ratios[phase] = max(0.05, ratios[phase] + delta)
+                if phase in accumulated:
+                    accumulated[phase] += delta
+
+    for phase, delta in accumulated.items():
+        if delta > 0:
+            delta = min(delta, STYLE_ADJUSTMENT_CAP)
+        else:
+            delta = max(delta, -STYLE_ADJUSTMENT_CAP)
+        if phase in ratios:
+            ratios[phase] = max(0.05, ratios[phase] + delta)
 
     # 3. Apply style rules for min/max enforcement on ratios
     all_styles = _normalize_styles(style)


### PR DESCRIPTION
## Summary
- cap combined style adjustments to avoid over-shifting phase ratios
- document style-specific ratio rules and clarify cap rationale

## Testing
- `python -m pip install -r requirements.txt` *(fails: could not find packages)*

------
https://chatgpt.com/codex/tasks/task_e_684acc37e8a0832ea74cc6013cd03240