### PR TITLE
Update taper conditioning and tag terminology

### DIFF
--- a/data/conditioning_bank.json
+++ b/data/conditioning_bank.json
@@ -61,7 +61,7 @@
     "equipment": [],
     "phases": ["SPP"],
     "system": "glycolytic",
-    "modality": "grappling",
+    "modality": "grappler",
     "duration": "5x4min w/30s rest",
     "intensity": "high",
     "tags": ["grip", "core", "conditioning"],
@@ -497,7 +497,7 @@
     "phases": ["SPP"],
     "system": "glycolytic",
     "duration": "5x30s max reps, 90s rest",
-    "tags": ["wrestling", "eccentric"],
+    "tags": ["wrestler", "eccentric"],
     "notes": "POSTERIOR CHAIN: 72h after deadlifts. GPP: Limit to 3 sets"
   },
   {
@@ -510,7 +510,7 @@
     "notes": "SHOULDER RECOVERY: Reduce volume if bench press >85% 1RM that week"
   },
   {
-    "name": "Grappling Escape Chains",
+    "name": "Grappler Escape Chains",
     "equipment": [],
     "phases": ["SPP"],
     "system": "glycolytic",
@@ -614,7 +614,7 @@
     "notes": "HAMSTRING ALERT: Replace with bike sprints if tight. GRADE: 15-20% incline"
   },
   {
-    "name": "Wrestling Shot Series",
+    "name": "Wrestler Shot Series",
     "equipment": [],
     "phases": ["SPP"],
     "system": "glycolytic",
@@ -769,7 +769,7 @@
     "phases": ["SPP"],
     "system": "glycolytic",
     "duration": "10x20s max reps, 40s rest",
-    "tags": ["wrestling", "eccentric"],
+    "tags": ["wrestler", "eccentric"],
     "notes": "QUAD LOAD: Must pass bodyweight squat depth test first"
   },
   {
@@ -872,12 +872,12 @@
     "notes": "SIMULATION: Begin rounds already at 70% fatigue"
   },
   {
-    "name": "Wrestling Chain Reaction Sparring",
+    "name": "Wrestler Chain Reaction Sparring",
     "equipment": [],
     "phases": ["SPP"],
     "system": "glycolytic",
     "duration": "8x90s (live transitions)",
-    "tags": ["wrestling", "reactive"],
+    "tags": ["wrestler", "reactive"],
     "notes": "PARTNER REQUIRED: Switch attacker/defender every round"
   },
   {
@@ -1165,7 +1165,7 @@
   "equipment": [],
   "phases": ["GPP"],
   "system": "glycolytic",
-  "modality": "wrestling",
+  "modality": "wrestler",
   "duration": "8x20s on/1:40 off",
   "intensity": "RPE 8",
   "tags": ["eccentric", "reactive"],
@@ -1290,7 +1290,7 @@
   "equipment": [],
   "phases": ["GPP"],
   "system": "glycolytic",
-  "modality": "grappling",
+  "modality": "grappler",
   "duration": "5x45s on/1:15 off",
   "intensity": "RPE 8",
   "tags": ["grip", "reactive"],
@@ -1555,7 +1555,7 @@
     "equipment": ["Partner"],
     "phases": ["SPP"],
     "system": "aerobic",
-    "modality": "grappling",
+    "modality": "grappler",
     "duration": "20min continuous",
     "intensity": "30% effort",
     "tags": ["aerobic", "bjj", "recovery", "transition"],
@@ -1573,14 +1573,14 @@
     "notes": "Emphasize angles, not explosiveness"
   },
   {
-    "name": "Wrestling Chain Drills (50% Effort)",
+    "name": "Wrestler Chain Drills (50% Effort)",
     "equipment": ["Partner"],
     "phases": ["SPP"],
     "system": "aerobic",
-    "modality": "wrestling",
+    "modality": "wrestler",
     "duration": "15min continuous",
     "intensity": "low",
-    "tags": ["aerobic", "wrestling", "transition", "skill"],
+    "tags": ["aerobic", "wrestler", "transition", "skill"],
     "notes": "No resistance; technique only"
   },
   {

--- a/data/exercise_bank.json
+++ b/data/exercise_bank.json
@@ -94,7 +94,7 @@
   },
   {
     "name": "Band-Resisted Sprawl to Sprint",
-    "category": "wrestling",
+    "category": "wrestler",
     "phases": [
       "TAPER"
     ],
@@ -283,7 +283,7 @@
   },
   {
     "name": "Zercher Squat → Sprawl Jump",
-    "category": "wrestling",
+    "category": "wrestler",
     "phases": [
       "SPP"
     ],
@@ -1823,7 +1823,7 @@
     "equipment": "heavy_bag"
   },
   {
-    "name": "Wrestling Shot Drill (Repetitive)",
+    "name": "Wrestler Shot Drill (Repetitive)",
     "category": "combat",
     "phases": [
       "SPP"

--- a/data/style_conditioning_bank.json
+++ b/data/style_conditioning_bank.json
@@ -504,7 +504,7 @@
       "SPP"
     ],
     "system": "Glycolytic",
-    "modality": "cage wrestling",
+    "modality": "cage wrestler",
     "duration": "20m sled push → 10 KB swings → x5 rounds",
     "intensity": "90% effort",
     "tags": [
@@ -543,7 +543,7 @@
       "SPP"
     ],
     "system": "Glycolytic",
-    "modality": "dirty grappling",
+    "modality": "dirty grappler",
     "duration": "30s bear hug carry → 10 knees → x6 rounds",
     "intensity": "Violent intent",
     "tags": [
@@ -786,7 +786,7 @@
       "brawler",
       "mma"
     ],
-    "notes": "Golden era catch wrestling conditioning",
+    "notes": "Golden era catch wrestler conditioning",
     "equipment_note": "95lb barbell, no gloves"
   },
   {
@@ -984,7 +984,7 @@
       "mma",
       "boxing"
     ],
-    "notes": "Develops underhook/overhook endurance and explosive lifts for wrestling-based clinch.",
+    "notes": "Develops underhook/overhook endurance and explosive lifts for wrestler-based clinch.",
     "equipment_note": "50-70lb sandbag"
   },
   {
@@ -1122,7 +1122,7 @@
       "clinch_fighter",
       "mma"
     ],
-    "notes": "Snatches mimic explosive head control adjustments for cage wrestling.",
+    "notes": "Snatches mimic explosive head control adjustments for cage wrestler.",
     "equipment_note": "16-24kg KB"
   },
   {
@@ -1343,7 +1343,7 @@
     "tags": [
       "clinch_fighter",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Develops late-round takedown defense from overhook positions.",
     "equipment_note": "Bands anchored at shoulder height"
@@ -2480,7 +2480,7 @@
   {
     "name": "Clinch Knee Devastation",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -3114,7 +3114,7 @@
       "pressure_fighter",
       "mma"
     ],
-    "notes": "Mimics cage cutting and wrestling recovery.",
+    "notes": "Mimics cage cutting and wrestler recovery.",
     "equipment_note": "Low sled for MMA posture"
   },
   {
@@ -3311,7 +3311,7 @@
       "pressure_fighter",
       "mma"
     ],
-    "notes": "Simulates scrambles in grappling exchanges.",
+    "notes": "Simulates scrambles in grappler exchanges.",
     "equipment_note": "Concrete floor ideal"
   },
   {
@@ -3492,8 +3492,8 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling",
-      "grappling"
+      "wrestler",
+      "grappler"
     ],
     "notes": "Partner counters takedown – you must immediately transition to back control.",
     "equipment_note": "Use crash pads for throws"
@@ -3514,7 +3514,7 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Bands on hips to resist sprawl recovery.",
     "equipment_note": "Heavy bands only"
@@ -3575,7 +3575,7 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Emphasize smooth hip movement.",
     "equipment_note": "Use soft mats"
@@ -3596,7 +3596,7 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Bands around waist for resistance.",
     "equipment_note": "Partner applies light pressure"
@@ -3604,7 +3604,7 @@
   {
     "name": "Submission to Sweep Chain",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -3637,7 +3637,7 @@
       "scrambler",
       "mma",
       "muay_thai",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Partner resists – you must chain takedowns.",
     "equipment_note": "Wear rash guards"
@@ -3679,7 +3679,7 @@
       "scrambler",
       "mma",
       "striking",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Coach signals shot after random strikes.",
     "equipment_note": "MMA gloves on"
@@ -3719,7 +3719,7 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Partner starts in tight front headlock.",
     "equipment_note": "Sprawl shorts recommended"
@@ -3770,7 +3770,7 @@
     "name": "Strike to Submission Chain",
     "equipment": [
       "Punching Bag",
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -3803,15 +3803,15 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Partner provides light resistance.",
-    "equipment_note": "Wrestling shoes optional"
+    "equipment_note": "Wrestler shoes optional"
   },
   {
     "name": "Flying Sub Scramble",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -3883,7 +3883,7 @@
     "tags": [
       "scrambler",
       "mma",
-      "wrestling"
+      "wrestler"
     ],
     "notes": "Partner defends first 3 seconds.",
     "equipment_note": "Rash guards recommended"
@@ -3891,7 +3891,7 @@
   {
     "name": "Mat Shark",
     "equipment": [
-      "Grappling Dummy",
+      "Grappler Dummy",
       "Bands"
     ],
     "phases": [
@@ -3996,7 +3996,7 @@
   {
     "name": "Twister Protocol",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -4138,7 +4138,7 @@
   {
     "name": "Peruvian Necktie Drill",
     "equipment": [
-      "Grappling Dummy",
+      "Grappler Dummy",
       "Bands"
     ],
     "phases": [
@@ -4280,7 +4280,7 @@
   {
     "name": "Ezekiel from Hell",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -4380,7 +4380,7 @@
   {
     "name": "Japanese Necktie Drill",
     "equipment": [
-      "Grappling Dummy"
+      "Grappler Dummy"
     ],
     "phases": [
       "SPP"
@@ -4422,7 +4422,7 @@
     "equipment_note": "Bag should swing minimally."
   },
   {
-    "name": "Wall-Wrestling Pummel Rounds",
+    "name": "Wall-Wrestler Pummel Rounds",
     "equipment": ["wall", "mma gloves"],
     "phases": ["gpp"],
     "system": "glycolytic",
@@ -4479,7 +4479,7 @@
     "intensity": "high",
     "tags": ["mma", "scrambler"],
     "notes": "Sprawl, then spring up into 2 knees + 2 elbows.",
-    "equipment_note": "Use wrestling mat for knee protection."
+    "equipment_note": "Use wrestler mat for knee protection."
   },
   {
     "name": "Counter Striker's Shell Defense Drill",
@@ -4495,7 +4495,7 @@
   },
   {
     "name": "Submission Chain Fatigue Drill",
-    "equipment": ["grappling dummy"],
+    "equipment": ["grappler dummy"],
     "phases": ["gpp"],
     "system": "glycolytic",
     "modality": "interval",
@@ -4528,7 +4528,7 @@
     "intensity": "max",
     "tags": ["scrambler", "mma"],
     "notes": "Partner signals shot randomly. React with sprawl then immediate takedown.",
-    "equipment_note": "Use wrestling shoes if available."
+    "equipment_note": "Use wrestler shoes if available."
   },
   {
     "name": "Lateral Escape Plyo Pushoffs",
@@ -4612,7 +4612,7 @@
     "intensity": "max",
     "tags": ["mma", "scrambler", "wrestler"],
     "notes": "Sprawl, then explode into double-leg shot. Full recovery between reps.",
-    "equipment_note": "Use wrestling mat for knee protection."
+    "equipment_note": "Use wrestler mat for knee protection."
   },
   {
     "name": "Lateral Plyo Pushoffs",
@@ -4916,7 +4916,7 @@
   },
   {
     "name": "Ground-and-Pound Bursts",
-    "equipment": ["grappling dummy"],
+    "equipment": ["grappler dummy"],
     "phases": ["gpp"],
     "system": "atp-pcr",
     "modality": "strike",
@@ -5320,7 +5320,7 @@
     "intensity": "moderate",
     "tags": ["mma", "scrambler"],
     "notes": "Continuous hip escapes down mat length.",
-    "equipment_note": "Use wrestling shoes."
+    "equipment_note": "Use wrestler shoes."
   },
   {
     "name": "Distance Striker's Teep Maintenance",

--- a/data/style_specific_exercises
+++ b/data/style_specific_exercises
@@ -6,7 +6,7 @@ style_specific_exercises = [
         "method": "strength",
         "movement": "static_hold",
         "type": "isometric",
-        "tags": ["grip", "wrestling", "bjj", "style_grappler", "style_wrestler"],
+        "tags": ["grip", "wrestler", "bjj", "style_grappler", "style_wrestler"],
         "equipment": "plates"
     },
     {

--- a/data/style_taper_conditioning.json
+++ b/data/style_taper_conditioning.json
@@ -1,470 +1,861 @@
 [
   {
     "name": "Counter-Striker Snap Hops",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "system": "ATP-PCr",
     "modality": "reactive timing",
     "duration": "4x3 ankle hops (quick ground contact)",
     "intensity": "50% effort",
-    "tags": ["boxing", "mma", counter_striker"],
+    "tags": [
+      "boxing",
+      "mma",
+      "counter_striker"
+    ],
     "notes": "Trains quick reset after defensive moves",
     "equipment_note": "Mat or grass surface"
   },
   {
     "name": "Clinch Frame Throws",
-    "equipment": ["Med Ball"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Med Ball"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "system": "ATP-PCr",
     "modality": "upper-body explosiveness",
     "duration": "5x med ball chest throws (6lb)",
     "intensity": "60% power",
-    "tags": ["muay_thai", "mma", clinch_fighter"],
+    "tags": [
+      "muay_thai",
+      "mma",
+      "clinch_fighter"
+    ],
     "notes": "Simulates framing explosiveness in clinch",
     "equipment_note": "Wall target at chest height"
   },
   {
     "name": "Scrambler Lateral Bound",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "system": "ATP-PCr",
     "modality": "hip switch power",
     "duration": "3x5 lateral bounds (sub-max distance)",
     "intensity": "50% effort",
-    "tags": ["wrestler", "mma", "scrambler"],
+    "tags": [
+      "wrestler",
+      "mma",
+      "scrambler"
+    ],
     "notes": "Mimics shot recovery movements",
     "equipment_note": "Mark landing zones 3ft apart"
   },
   {
     "name": "Kicker Step-Bounce",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "system": "ATP-PCr",
     "modality": "leg recoil",
     "duration": "4x3 step-back bounces (off lead leg)",
     "intensity": "40% effort",
-    "tags": ["kickboxing", "kicker", "mma"],
+    "tags": [
+      "kickboxing",
+      "kicker",
+      "mma"
+    ],
     "notes": "Primes teep/kick retraction speed",
     "equipment_note": "Flat surface only"
   },
   {
     "name": "Pressure Fighter Box Drive",
-    "equipment": ["Plyo Box"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Plyo Box"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 box step-ups (explosive drive)",
     "intensity": "50% height",
-    "tags": ["boxing", "mma", "kickboxing", "muay thai", "pressure_fighter"],
+    "tags": [
+      "boxing",
+      "mma",
+      "kickboxing",
+      "muay thai",
+      "pressure_fighter"
+    ],
     "notes": "Develops forward knee drive for cutting off ring",
-    "equipment_note": "12\" box height"
+    "equipment_note": "12\" box height",
+    "system": "ATP-PCr"
   },
   {
     "name": "Submission Hunter Hip Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 seated hip pops (from guard)",
     "intensity": "Light explosiveness",
-    "tags": ["grappling", "mma", submission_hunter"],
+    "tags": [
+      "grappler",
+      "mma",
+      "submission_hunter"
+    ],
     "notes": "Trains explosive hip elevation for subs",
-    "equipment_note": "Mat surface required"
+    "equipment_note": "Mat surface required",
+    "system": "ATP-PCr"
   },
   {
     "name": "Hybrid Stance Switch",
-    "equipment": ["Agility Ladder"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Agility Ladder"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 stance switches (with arm swing)",
     "intensity": "60% speed",
-    "tags": ["mma", "boxing", "muay thai", "kickboxing", hybrid"],
+    "tags": [
+      "mma",
+      "boxing",
+      "muay thai",
+      "kickboxing",
+      "hybrid"
+    ],
     "notes": "Sharpens stance transition reflexes",
-    "equipment_note": "Ladder optional"
+    "equipment_note": "Ladder optional",
+    "system": "ATP-PCr"
   },
   {
     "name": "Brawler Overhand Pop",
-    "equipment": ["Med Ball"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Med Ball"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "5x3 med ball slams (8lb)",
     "intensity": "70% power",
-    "tags": ["boxing", "brawler"],
+    "tags": [
+      "boxing",
+      "brawler"
+    ],
     "notes": "Mimics overhand right mechanics",
-    "equipment_note": "Concrete wall target"
+    "equipment_note": "Concrete wall target",
+    "system": "ATP-PCr"
   },
   {
     "name": "Distance Striker Skip-Back",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 backward skips (quick toe-off)",
     "intensity": "50% effort",
-    "tags": ["kickboxing", "mma", "boxing", distance_striker"],
+    "tags": [
+      "kickboxing",
+      "mma",
+      "boxing",
+      "distance_striker"
+    ],
     "notes": "Trains defensive footwork elasticity",
-    "equipment_note": "Grass/turf preferred"
+    "equipment_note": "Grass/turf preferred",
+    "system": "ATP-PCr"
   },
   {
     "name": "Grappler Takedown Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 level-change jumps",
     "intensity": "40% explosion",
-    "tags": ["wrestler", "grappler", "mma"],
+    "tags": [
+      "wrestler",
+      "grappler",
+      "mma"
+    ],
     "notes": "Primes shot explosiveness",
-    "equipment_note": "Knee sleeves optional"
+    "equipment_note": "Knee sleeves optional",
+    "system": "ATP-PCr"
   },
   {
     "name": "MMA Cage Push-Off",
-    "equipment": ["Wall"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Wall"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 wall push jumps (single leg)",
     "intensity": "50% power",
-    "tags": ["mma", "scrambler"],
+    "tags": [
+      "mma",
+      "scrambler"
+    ],
     "notes": "Simulates cage scramble rebounds",
-    "equipment_note": "Padded wall ideal"
+    "equipment_note": "Padded wall ideal",
+    "system": "ATP-PCr"
   },
   {
     "name": "Muay Thai Knee Skip",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 skipping knee drives",
     "intensity": "30% power",
-    "tags": ["muay_thai", "clinch_fighter"],
+    "tags": [
+      "muay_thai",
+      "clinch_fighter"
+    ],
     "notes": "Maintains clinch knee timing",
-    "equipment_note": "Focus on rhythm"
+    "equipment_note": "Focus on rhythm",
+    "system": "ATP-PCr"
   },
   {
     "name": "Counter Striker Slip-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 slip-to-vertical jumps",
     "intensity": "50% height",
-    "tags": ["boxing", "mma", counter_striker"],
+    "tags": [
+      "boxing",
+      "mma",
+      "counter_striker"
+    ],
     "notes": "Links head movement to counter explosiveness",
-    "equipment_note": "Soft surface"
+    "equipment_note": "Soft surface",
+    "system": "ATP-PCr"
   },
   {
     "name": "Pressure Fighter Stomp",
-    "equipment": ["Tire"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Tire"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 tire stomps (alternating)",
     "intensity": "60% power",
-    "tags": ["mma", "pressure_fighter"],
+    "tags": [
+      "mma",
+      "pressure_fighter"
+    ],
     "notes": "Develops forward pressure mechanics",
-    "equipment_note": "300lb tire"
+    "equipment_note": "300lb tire",
+    "system": "ATP-PCr"
   },
   {
     "name": "Kicker Switch Hop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 stance-switch hops",
     "intensity": "40% effort",
-    "tags": ["muay_thai", "mma", kicker"],
+    "tags": [
+      "muay_thai",
+      "mma",
+      "kicker"
+    ],
     "notes": "Trains kick setup footwork",
-    "equipment_note": "Mark stance width"
+    "equipment_note": "Mark stance width",
+    "system": "ATP-PCr"
   },
   {
     "name": "Submission Hunter Bridge Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x3 bridge-to-hip lifts",
     "intensity": "Light explosiveness",
-    "tags": ["grappling", "mma", submission_hunter"],
+    "tags": [
+      "grappler",
+      "mma",
+      "submission_hunter"
+    ],
     "notes": "Maintains explosive bridging for subs",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
     "name": "Hybrid Sprawl-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 sprawl-to-vertical jumps",
     "intensity": "50% height",
-    "tags": ["mma", "distance_fighter"],
+    "tags": [
+      "mma",
+      "distance_fighter"
+    ],
     "notes": "Links TDD to stand-up explosiveness",
-    "equipment_note": "Grass/turf"
+    "equipment_note": "Grass/turf",
+    "system": "ATP-PCr"
   },
   {
     "name": "Brawler Body Shot Throw",
-    "equipment": ["Med Ball"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Med Ball"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "5x3 rotational med ball throws",
     "intensity": "60% power",
-    "tags": ["boxing", "brawler"],
+    "tags": [
+      "boxing",
+      "brawler"
+    ],
     "notes": "Mimics hook/uppercut chain explosiveness",
-    "equipment_note": "10lb ball"
+    "equipment_note": "10lb ball",
+    "system": "ATP-PCr"
   },
   {
     "name": "Distance Striker Teep Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 lead-leg drive pops",
     "intensity": "40% effort",
-    "tags": ["muay_thai", "kicker", "mma", distance_striker"],
+    "tags": [
+      "muay_thai",
+      "kicker",
+      "mma",
+      "distance_striker"
+    ],
     "notes": "Primes teep retraction speed",
-    "equipment_note": "Wall for balance"
+    "equipment_note": "Wall for balance",
+    "system": "ATP-PCr"
   },
   {
     "name": "Grappler Granby Roll",
-    "equipment": ["Mat"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Mat"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x3 Granby pop-ups",
     "intensity": "Light explosiveness",
-    "tags": ["wrestling", "mma", grappling"],
+    "tags": [
+      "wrestler",
+      "mma",
+      "grappler"
+    ],
     "notes": "Sharpens rolling explosiveness",
-    "equipment_note": "BJJ mat"
+    "equipment_note": "BJJ mat",
+    "system": "ATP-PCr"
   },
   {
     "name": "MMA Sprawl-Bounce",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 sprawl-to-forward jumps",
     "intensity": "50% distance",
-    "tags": ["mma", "scrambler"],
+    "tags": [
+      "mma",
+      "scrambler"
+    ],
     "notes": "Trains shot defense to re-engagement",
-    "equipment_note": "Mark 3ft jump target"
+    "equipment_note": "Mark 3ft jump target",
+    "system": "ATP-PCr"
   },
   {
     "name": "Muay Thai Clinch Pop",
-    "equipment": ["Partner"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Partner"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 pummel-to-frame jumps",
     "intensity": "30% power",
-    "tags": ["muay_thai", "clinch_fighter"],
+    "tags": [
+      "muay_thai",
+      "clinch_fighter"
+    ],
     "notes": "Maintains clinch posture explosiveness",
-    "equipment_note": "Light contact only"
+    "equipment_note": "Light contact only",
+    "system": "ATP-PCr"
   },
   {
     "name": "Counter Striker Pull-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 pull-counter to jump",
     "intensity": "50% height",
-    "tags": ["boxing", "counter_striker"],
+    "tags": [
+      "boxing",
+      "counter_striker"
+    ],
     "notes": "Links defensive pulls to counter bursts",
-    "equipment_note": "Mirror for form"
+    "equipment_note": "Mirror for form",
+    "system": "ATP-PCr"
   },
   {
     "name": "Pressure Fighter Cutoff Hop",
-    "equipment": ["Agility Ladder"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Agility Ladder"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 lateral cutoff hops",
     "intensity": "50% effort",
-    "tags": ["boxing", "pressure_fighter"],
+    "tags": [
+      "boxing",
+      "pressure_fighter"
+    ],
     "notes": "Trains angle-cutting footwork",
-    "equipment_note": "Ladder optional"
+    "equipment_note": "Ladder optional",
+    "system": "ATP-PCr"
   },
   {
     "name": "Kicker Switch-Kick Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 switch-kick footwork pops",
     "intensity": "40% effort",
-    "tags": ["kickboxing", "mma", kicker"],
+    "tags": [
+      "kickboxing",
+      "mma",
+      "kicker"
+    ],
     "notes": "Primes southpaw-orthodox kick transitions",
-    "equipment_note": "Wall support"
+    "equipment_note": "Wall support",
+    "system": "ATP-PCr"
   },
   {
     "name": "Submission Hunter Sit-Out Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 sit-out to stand jumps",
     "intensity": "Light explosiveness",
-    "tags": ["grappling", "mma", submission_hunter"],
+    "tags": [
+      "grappler",
+      "mma",
+      "submission_hunter"
+    ],
     "notes": "Maintains explosive stand-ups",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
     "name": "Hybrid Takedown Hop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 shot-entry hops",
     "intensity": "50% distance",
-    "tags": ["mma", "wrestler", grappler"],
+    "tags": [
+      "mma",
+      "wrestler",
+      "grappler"
+    ],
     "notes": "Sharpens level-change timing",
-    "equipment_note": "Mark 3ft target"
+    "equipment_note": "Mark 3ft target",
+    "system": "ATP-PCr"
   },
   {
     "name": "Brawler Body Roll",
-    "equipment": ["Med Ball"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Med Ball"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "5x3 med ball body drops",
     "intensity": "60% power",
-    "tags": ["boxing", "mma", brawler"],
+    "tags": [
+      "boxing",
+      "mma",
+      "brawler"
+    ],
     "notes": "Mimics body shot absorption/recovery",
-    "equipment_note": "20lb ball to floor"
+    "equipment_note": "20lb ball to floor",
+    "system": "ATP-PCr"
   },
   {
     "name": "Distance Striker Skip-In",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 forward skips (quick plant)",
     "intensity": "50% effort",
-    "tags": ["kickboxing", "distance_striker"],
+    "tags": [
+      "kickboxing",
+      "distance_striker"
+    ],
     "notes": "Trains blitz entry elasticity",
-    "equipment_note": "Even surface"
+    "equipment_note": "Even surface",
+    "system": "ATP-PCr"
   },
   {
     "name": "Grappler Hip Heist Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 hip heist pops",
     "intensity": "Light explosiveness",
-    "tags": ["wrestling", "mma", grappling"],
+    "tags": [
+      "wrestler",
+      "mma",
+      "grappler"
+    ],
     "notes": "Maintains mat return explosiveness",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
     "name": "MMA Spin-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x3 spin-to-jump transitions",
     "intensity": "40% power",
-    "tags": ["mma", "scrambler"],
+    "tags": [
+      "mma",
+      "scrambler"
+    ],
     "notes": "Trains cage scramble reorientation",
-    "equipment_note": "Open space"
+    "equipment_note": "Open space",
+    "system": "ATP-PCr"
   },
   {
     "name": "Muay Thai Long Guard Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 long guard advance hops",
     "intensity": "30% effort",
-    "tags": ["muay_thai", "distance_striker"],
+    "tags": [
+      "muay_thai",
+      "distance_striker"
+    ],
     "notes": "Maintains teep-ready footwork",
-    "equipment_note": "Wall for balance"
+    "equipment_note": "Wall for balance",
+    "system": "ATP-PCr"
   },
   {
     "name": "Counter Striker Check-Hop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 check hook to jump",
     "intensity": "50% height",
-    "tags": ["boxing", "counter_striker"],
+    "tags": [
+      "boxing",
+      "counter_striker"
+    ],
     "notes": "Links pull counters to lateral movement",
-    "equipment_note": "Mirror for form"
+    "equipment_note": "Mirror for form",
+    "system": "ATP-PCr"
   },
   {
     "name": "Kicker Roundhouse Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 pivot hops",
     "intensity": "40% effort",
-    "tags": ["kickboxing", "mma", kicker"],
+    "tags": [
+      "kickboxing",
+      "mma",
+      "kicker"
+    ],
     "notes": "Maintains kick torque mechanics",
-    "equipment_note": "Wall support"
+    "equipment_note": "Wall support",
+    "system": "ATP-PCr"
   },
   {
     "name": "Submission Hunter Arm Drag Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 arm drag to jump",
     "intensity": "Light explosiveness",
-    "tags": ["grappling", "mma", submission_hunter"],
+    "tags": [
+      "grappler",
+      "mma",
+      "submission_hunter"
+    ],
     "notes": "Sharpens explosive entries to subs",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
     "name": "Hybrid Sprawl-Spin",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 sprawl-to-spin jumps",
     "intensity": "40% rotation",
-    "tags": ["mma"],
+    "tags": [
+      "mma"
+    ],
     "notes": "Trains TDD to back-take transitions",
-    "equipment_note": "Open space"
+    "equipment_note": "Open space",
+    "system": "ATP-PCr"
   },
   {
     "name": "Brawler Rope Hop",
-    "equipment": ["Battle Ropes"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Battle Ropes"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 rope waves to jump",
     "intensity": "50% power",
-    "tags": ["boxing", "brawler"],
+    "tags": [
+      "boxing",
+      "brawler"
+    ],
     "notes": "Mimics flurry-to-reset explosiveness",
-    "equipment_note": "1.5\" ropes"
+    "equipment_note": "1.5\" ropes",
+    "system": "ATP-PCr"
   },
   {
     "name": "Distance Striker Slide-Hop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 lateral slide jumps",
     "intensity": "50% effort",
-    "tags": ["kickboxing", "distance_striker"],
+    "tags": [
+      "kickboxing",
+      "distance_striker"
+    ],
     "notes": "Maintains angle-cutting explosiveness",
-    "equipment_note": "Mark 3ft zones"
+    "equipment_note": "Mark 3ft zones",
+    "system": "ATP-PCr"
   },
   {
     "name": "Grappler Knee Cut Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x4 knee cut drives",
     "intensity": "Light explosiveness",
-    "tags": ["wrestling", "mma", grappling"],
+    "tags": [
+      "wrestler",
+      "mma",
+      "grappler"
+    ],
     "notes": "Sharpens guard pass entries",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
     "name": "MMA Cage Jump",
-    "equipment": ["Wall"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Wall"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 wall push-off jumps",
     "intensity": "50% height",
-    "tags": ["mma", "scrambler"],
+    "tags": [
+      "mma",
+      "scrambler"
+    ],
     "notes": "Trains cage rebound explosiveness",
-    "equipment_note": "Padded wall"
+    "equipment_note": "Padded wall",
+    "system": "ATP-PCr"
   },
   {
     "name": "Muay Thai Skip-Knee",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 skip knee drives",
     "intensity": "30% power",
-    "tags": ["muay_thai", "clinch_fighter"],
+    "tags": [
+      "muay_thai",
+      "clinch_fighter"
+    ],
     "notes": "Maintains clinch knee timing",
-    "equipment_note": "Focus on rhythm"
+    "equipment_note": "Focus on rhythm",
+    "system": "ATP-PCr"
   },
   {
     "name": "Counter Striker Roll-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 shoulder roll to jump",
     "intensity": "50% height",
-    "tags": ["boxing", "counter_striker"],
+    "tags": [
+      "boxing",
+      "counter_striker"
+    ],
     "notes": "Links defensive rolls to counters",
-    "equipment_note": "Soft surface"
+    "equipment_note": "Soft surface",
+    "system": "ATP-PCr"
   },
   {
     "name": "Pressure Fighter Stomp-Switch",
-    "equipment": ["Tire"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Tire"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 stomp-to-stance switch",
     "intensity": "50% speed",
-    "tags": ["mma", "pressure_fighter"],
+    "tags": [
+      "mma",
+      "pressure_fighter"
+    ],
     "notes": "Trains pressure footwork transitions",
-    "equipment_note": "200lb tire"
+    "equipment_note": "200lb tire",
+    "system": "ATP-PCr"
   },
   {
     "name": "Kicker Switch-Teep Pop",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "4x3 stance-switch teep pops",
     "intensity": "40% effort",
-    "tags": ["muay_thai", "kicker"],
+    "tags": [
+      "muay_thai",
+      "kicker"
+    ],
     "notes": "Maintains teep versatility",
-    "equipment_note": "Wall support"
+    "equipment_note": "Wall support",
+    "system": "ATP-PCr"
   },
   {
     "name": "Submission Hunter Bridge-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x3 bridge to stand jumps",
     "intensity": "Light explosiveness",
-    "tags": ["grappling", "mma", submission_hunter"],
+    "tags": [
+      "grappler",
+      "mma",
+      "submission_hunter"
+    ],
     "notes": "Sharpens explosive stand-ups from guard",
-    "equipment_note": "Mat required"
+    "equipment_note": "Mat required",
+    "system": "ATP-PCr"
   },
   {
-    "name": Shot-Jump",
-    "equipment": ["Bodyweight"],
-    "phases": ["Taper"],
+    "name": "Shot-Jump",
+    "equipment": [
+      "Bodyweight"
+    ],
+    "phases": [
+      "Taper"
+    ],
     "duration": "3x5 shot to jump transitions",
     "intensity": "50% height",
-    "tags": ["mma"],
+    "tags": [
+      "mma"
+    ],
     "notes": "Links takedowns to stand-up bursts",
-    "equipment_note": "Mark 3ft target"
+    "equipment_note": "Mark 3ft target",
+    "system": "ATP-PCr"
   }
 ]

--- a/data/universal_gpp_conditioning.json
+++ b/data/universal_gpp_conditioning.json
@@ -84,7 +84,7 @@
     "intensity": "Max acceleration",
     "volume": "1–2x/week",
     "equipment": ["resistance band", "partner"],
-    "tags": ["explosive", "wrestling", "rate_of_force", "reactive", "conditioning"],
+    "tags": ["explosive", "wrestler", "rate_of_force", "reactive", "conditioning"],
     "notes": "Sport-specific shots against band resistance. <10s efforts w/ 1:5 work:rest ratio. Enhances first-step quickness."
   },
   {

--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -54,8 +54,8 @@ goal_tag_map = {
         "mobility", "hip_dominant", "balance", "eccentric", "unilateral", "adductors",
         "stability", "movement_quality", "range", "rehab_friendly"
     ],
-    "grappling": [
-        "wrestling", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
+    "grappler": [
+        "wrestler", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
         "manual_resistance", "positioning"
     ],
     "striking": [
@@ -159,15 +159,22 @@ def generate_conditioning_block(flags):
     weak_tags = expand_tags(weaknesses, weakness_tag_map)
 
     style_map = {
-        "mma": "mma", "boxer": "boxing", "kickboxer": "kickboxing",
-        "muay thai": "muay_thai", "bjj": "mma", "wrestler": "mma",
-        "grappler": "mma", "karate": "kickboxing"
+        "mma": "mma",
+        "boxer": "boxing",
+        "kickboxer": "kickboxing",
+        "muay thai": "muay_thai",
+        "bjj": "mma",
+        "wrestler": "mma",
+        "wrestling": "wrestler",
+        "grappler": "mma",
+        "grappling": "grappler",
+        "karate": "kickboxing",
     }
     fight_format = style_map.get(technical, "mma")
     energy_weights = format_weights.get(fight_format, {})
 
     format_tag_map = {
-        "mma": ["mma", "bjj", "wrestling"],
+        "mma": ["mma", "bjj", "wrestler"],
         "boxing": ["boxing"],
         "kickboxing": ["kickboxing", "muay_thai"],
         "muay_thai": ["muay_thai"]

--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -45,7 +45,7 @@ GOAL_NORMALIZER = {
     "Posterior Chain": "posterior_chain",
     "Knees": "quad_dominant",
     "Neck": "neck",
-    "Grappling": "grappling",
+    "Grappler": "grappler",
     "Striking": "striking",
     "Injury Prevention": "injury_prevention",
     "Mental Resilience": "mental_resilience",

--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -8,7 +8,7 @@ mindset_bank = {
         "motivation": "Start 'why log' (3x/week). Reconnect with deeper reasons to train.",
         "fear of losing": "Record 3 worst-case outcomes and evidence how you'd recover. Reduce emotional weight.",
         "fear of striking": "Shadowbox with relaxed breath for 3 rounds daily. Gradually build intent and aggression.",
-        "fear of takedowns": "Integrate wall wrestling reps with fixed grip/entry drills. Isolate fear with control.",
+        "fear of takedowns": "Integrate wall wrestler reps with fixed grip/entry drills. Isolate fear with control.",
         "generic": "Establish AM mental warm-up (1 min breathe, 3 affirmations, 1 visualization rep)."
     },
     "SPP": {

--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -168,8 +168,8 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
             "mobility", "hip_dominant", "balance", "eccentric", "unilateral", "adductors",
             "stability", "movement_quality", "range", "rehab_friendly"
         ],
-        "grappling": [
-            "wrestling", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
+        "grappler": [
+            "wrestler", "bjj", "grip", "rotational", "core", "unilateral", "tactical",
             "manual_resistance", "positioning"
         ],
         "striking": [

--- a/notes/brawler_conditioning_bank.json
+++ b/notes/brawler_conditioning_bank.json
@@ -303,7 +303,7 @@
     "equipment": ["Sled", "Kettlebell"],
     "phases": ["SPP"],
     "system": "Glycolytic",
-    "modality": "cage wrestling",
+    "modality": "cage wrestler",
     "duration": "20m sled push → 10 KB swings → x5 rounds",
     "intensity": "90% effort",
     "tags": ["brawler", "mma"],
@@ -327,7 +327,7 @@
     "equipment": ["Sandbag"],
     "phases": ["SPP"],
     "system": "Glycolytic",
-    "modality": "dirty grappling",
+    "modality": "dirty grappler",
     "duration": "30s bear hug carry → 10 knees → x6 rounds",
     "intensity": "Violent intent",
     "tags": ["brawler", "mma"],
@@ -475,7 +475,7 @@
     "duration": "20min: 5 cleans → 5 push presses → 5 squats",
     "intensity": "60% 1RM",
     "tags": ["brawler", "mma"],
-    "notes": "Golden era catch wrestling conditioning",
+    "notes": "Golden era catch wrestler conditioning",
     "equipment_note": "95lb barbell, no gloves"
   },
   {

--- a/notes/cheat_sheet.md
+++ b/notes/cheat_sheet.md
@@ -4,7 +4,7 @@ This document is a quick reference for the tags used throughout the fight camp b
 
 ## What Are Tags?
 
-Tags are short keywords attached to every drill or exercise. They describe what the movement trains (for example `core` or `explosive`) or who it suits (like `wrestling` or `muay_thai`). When the program builds your plan it looks at your goals, weaknesses and fighting style and then picks moves with the best matching tags.
+Tags are short keywords attached to every drill or exercise. They describe what the movement trains (for example `core` or `explosive`) or who it suits (like `wrestler` or `muay_thai`). When the program builds your plan it looks at your goals, weaknesses and fighting style and then picks moves with the best matching tags.
 
 Below is a list of all tags found in the banks. The descriptions are brief so you have a general idea of what each tag means.
 
@@ -18,7 +18,7 @@ Below is a list of all tags found in the banks. The descriptions are brief so yo
 - **arm_dominant** – general tag for arm dominant.
 - **athletic** – general tag for athletic.
 - **balance** – challenges balance.
-- **bjj** – grappling related.
+- **bjj** – grappler related.
 - **boxing** – striking specific.
 - **clinch** – general tag for clinch.
 - **cns_freshness** – general tag for cns freshness.
@@ -51,7 +51,7 @@ Below is a list of all tags found in the banks. The descriptions are brief so yo
 - **low_volume** – general tag for low volume.
 - **lunge_pattern** – general tag for lunge pattern.
 - **mental_toughness** – general tag for mental toughness.
-- **mma** – grappling related.
+- **mma** – grappler related.
 - **mobility** – improves joint mobility.
 - **muay_thai** – striking specific.
 - **overhead** – general tag for overhead.
@@ -82,7 +82,7 @@ Below is a list of all tags found in the banks. The descriptions are brief so yo
 - **upper_body** – upper body work.
 - **visual_processing** – trains eyes and coordination.
 - **work_capacity** – general tag for work capacity.
-- **wrestling** – grappling related.
+- **wrestler** – grappler related.
 - **zero_impact** – general tag for zero impact.
 
 ## Scoring Basics

--- a/notes/clinch_fighter_conditioning_bank.json
+++ b/notes/clinch_fighter_conditioning_bank.json
@@ -56,7 +56,7 @@
     "duration": "30s pummeling drills → 10 bodylock lifts → x5 rounds",
     "intensity": "85% effort",
     "tags": ["clinch_fighter", "mma", "boxing"],
-    "notes": "Develops underhook/overhook endurance and explosive lifts for wrestling-based clinch.",
+    "notes": "Develops underhook/overhook endurance and explosive lifts for wrestler-based clinch.",
     "equipment_note": "50-70lb sandbag"
   },
   {
@@ -140,7 +140,7 @@
     "duration": "10 KB snatches → 10 sprawls → x5 rounds",
     "intensity": "90% effort",
     "tags": ["clinch_fighter", "mma"],
-    "notes": "Snatches mimic explosive head control adjustments for cage wrestling.",
+    "notes": "Snatches mimic explosive head control adjustments for cage wrestler.",
     "equipment_note": "16-24kg KB"
   },
   {
@@ -271,7 +271,7 @@
     "modality": "defensive endurance",
     "duration": "30s band-resisted whizzers → 5 sprawls → x5 rounds",
     "intensity": "90% effort",
-    "tags": ["clinch_fighter", "mma", "wrestling"],
+    "tags": ["clinch_fighter", "mma", "wrestler"],
     "notes": "Develops late-round takedown defense from overhook positions.",
     "equipment_note": "Bands anchored at shoulder height"
   },

--- a/notes/conditioning_bank_tags.txt
+++ b/notes/conditioning_bank_tags.txt
@@ -30,7 +30,7 @@
   "low_cns",
   "clinch",
   "muay_thai",
-  "wrestling",
+  "wrestler",
   "eccentric",
   "striking",
   "bjj",

--- a/notes/exercise_bank_tags.txt
+++ b/notes/exercise_bank_tags.txt
@@ -57,5 +57,5 @@ unilateral
 upper_body
 visual_processing
 work_capacity
-wrestling
+wrestler
 zero_impact

--- a/notes/kicker_conditioning_bank.json
+++ b/notes/kicker_conditioning_bank.json
@@ -181,7 +181,7 @@
   },
   {
     "name": "Clinch Knee Devastation",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "muay thai clinch",

--- a/notes/pressure_fighter_conditioning.json
+++ b/notes/pressure_fighter_conditioning.json
@@ -260,7 +260,7 @@
     "duration": "20m sled push → 5 sprawls, 6 rounds",
     "intensity": "Bodyweight load",
     "tags": ["pressure_fighter", "mma"],
-    "notes": "Mimics cage cutting and wrestling recovery.",
+    "notes": "Mimics cage cutting and wrestler recovery.",
     "equipment_note": "Low sled for MMA posture"
   },
   {
@@ -380,7 +380,7 @@
     "duration": "10 sprawls → 10 burpee jumps, 6 rounds",
     "intensity": "No rest",
     "tags": ["pressure_fighter", "mma"],
-    "notes": "Simulates scrambles in grappling exchanges.",
+    "notes": "Simulates scrambles in grappler exchanges.",
     "equipment_note": "Concrete floor ideal"
   },
   {

--- a/notes/scrambler_conditioning_bank.json
+++ b/notes/scrambler_conditioning_bank.json
@@ -7,7 +7,7 @@
     "modality": "live reaction",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "90% explosiveness",
-    "tags": ["scrambler", "mma", "wrestling", "grappling"],
+    "tags": ["scrambler", "mma", "wrestler", "grappler"],
     "notes": "Partner counters takedown – you must immediately transition to back control.",
     "equipment_note": "Use crash pads for throws"
   },
@@ -19,7 +19,7 @@
     "modality": "defensive scrambling",
     "duration": "10 sprawl → spin sequences, 5 rounds",
     "intensity": "Max speed",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Bands on hips to resist sprawl recovery.",
     "equipment_note": "Heavy bands only"
   },
@@ -55,7 +55,7 @@
     "modality": "failed shot recovery",
     "duration": "15 shot → roll sequences, 5 rounds",
     "intensity": "85% effort",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Emphasize smooth hip movement.",
     "equipment_note": "Use soft mats"
   },
@@ -67,13 +67,13 @@
     "modality": "explosive standups",
     "duration": "20 stand-ups/min, 4 rounds",
     "intensity": "Max explosion",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Bands around waist for resistance.",
     "equipment_note": "Partner applies light pressure"
   },
   {
     "name": "Submission to Sweep Chain",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "transitional awareness",
@@ -91,7 +91,7 @@
     "modality": "live clinch work",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "90% effort",
-    "tags": ["scrambler", "mma", "muay_thai", "wrestling"],
+    "tags": ["scrambler", "mma", "muay_thai", "wrestler"],
     "notes": "Partner resists – you must chain takedowns.",
     "equipment_note": "Wear rash guards"
   },
@@ -115,7 +115,7 @@
     "modality": "mixed reactions",
     "duration": "3min rounds: 1-2 → shot, 1min rest x 4",
     "intensity": "85% speed",
-    "tags": ["scrambler", "mma", "striking", "wrestling"],
+    "tags": ["scrambler", "mma", "striking", "wrestler"],
     "notes": "Coach signals shot after random strikes.",
     "equipment_note": "MMA gloves on"
   },
@@ -139,7 +139,7 @@
     "modality": "defensive urgency",
     "duration": "15 escapes → 5 shots, 5 rounds",
     "intensity": "90% effort",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Partner starts in tight front headlock.",
     "equipment_note": "Sprawl shorts recommended"
   },
@@ -169,7 +169,7 @@
   },
   {
     "name": "Strike to Submission Chain",
-    "equipment": ["Punching Bag", "Grappling Dummy"],
+    "equipment": ["Punching Bag", "Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "hybrid transitions",
@@ -187,13 +187,13 @@
     "modality": "ground to stand",
     "duration": "10 granby rolls → 5 shots, 5 rounds",
     "intensity": "Explosive",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Partner provides light resistance.",
-    "equipment_note": "Wrestling shoes optional"
+    "equipment_note": "Wrestler shoes optional"
   },
   {
     "name": "Flying Sub Scramble",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "aerial transitions",
@@ -235,7 +235,7 @@
     "modality": "live reaction",
     "duration": "10 standing backtakes, 5 rounds",
     "intensity": "85% control",
-    "tags": ["scrambler", "mma", "wrestling"],
+    "tags": ["scrambler", "mma", "wrestler"],
     "notes": "Partner defends first 3 seconds.",
     "equipment_note": "Rash guards recommended"
   }

--- a/notes/submission_hunter_conditioning_bank.json
+++ b/notes/submission_hunter_conditioning_bank.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Mat Shark",
-    "equipment": ["Grappling Dummy", "Bands"],
+    "equipment": ["Grappler Dummy", "Bands"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "transition chains",
@@ -61,7 +61,7 @@
   },
   {
     "name": "Twister Protocol",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "back control",
@@ -145,7 +145,7 @@
   },
   {
     "name": "Peruvian Necktie Drill",
-    "equipment": ["Grappling Dummy", "Bands"],
+    "equipment": ["Grappler Dummy", "Bands"],
     "phases": ["SPP"],
     "system": "ATP-PCr",
     "modality": "entry timing",
@@ -229,7 +229,7 @@
   },
   {
     "name": "Ezekiel from Hell",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "Glycolytic",
     "modality": "sleeve control",
@@ -289,7 +289,7 @@
   },
   {
     "name": "Japanese Necktie Drill",
-    "equipment": ["Grappling Dummy"],
+    "equipment": ["Grappler Dummy"],
     "phases": ["SPP"],
     "system": "ATP-PCr",
     "modality": "angle creation",


### PR DESCRIPTION
## Summary
- fix invalid JSON for style taper conditioning drills
- add missing energy system info to taper conditioning drills
- rename wrestling→wrestler and grappling→grappler throughout repo
- map old style names to new ones in `style_map`

## Testing
- `python -m py_compile fightcamp/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684adc1dadec832e824beec7d0b17974