### PR TITLE
Handle injury location from form

### DIFF
--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -124,6 +124,7 @@ async def handle_submission(request: Request):
     except (TypeError, ValueError):
         training_frequency = len(training_days)
     injuries = get_value("Any injuries or areas you need to work around?", fields)
+    injury_location = get_value("Injury Location", fields).lower()
     key_goals = get_value("What are your key performance goals?", fields)
     weak_areas = get_value("Where do you feel weakest right now?", fields)
     training_preference = get_value("Do you prefer certain training styles?", fields)
@@ -182,6 +183,7 @@ async def handle_submission(request: Request):
         "days_available": len(training_days),
         "training_days": training_days,
         "injuries": normalize_list(injuries),
+        "injury_location": injury_location,
         "style_technical": raw_tech_style,
         "style_tactical": tactical_styles,
         "weaknesses": normalize_list(weak_areas),
@@ -390,6 +392,7 @@ async def handle_submission(request: Request):
         f"- Phase Days: {phase_weeks['days']['GPP']} GPP / {phase_weeks['days']['SPP']} SPP / {phase_weeks['days']['TAPER']} Taper",
         f"- Fatigue Level: {fatigue}",
         f"- Injuries: {injuries}",
+        f"- Injury Location: {injury_location}",
         f"- Training Availability: {available_days}",
         f"- Weaknesses: {weak_areas}",
         f"- Key Goals: {key_goals}",


### PR DESCRIPTION
## Summary
- add Injury Location field to webhook payload handling
- store the lowercased location in the training context
- expose the injury location in the final doc

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b860ff4a0832ead4632a630571797