### PR TITLE
Implement rapidfuzz based fuzzy matching

### DIFF
--- a/fightcamp/injury_synonyms.py
+++ b/fightcamp/injury_synonyms.py
@@ -424,33 +424,36 @@ LOCATION_MAP = {
 }
 
 
-def canonicalize_injury_type(text: str) -> str | None:
-    """Return the canonical injury type for the given text.
+from rapidfuzz import fuzz
 
-    The function searches ``INJURY_SYNONYM_MAP`` for any phrase found in
-    ``text`` and returns the corresponding key. If no match is found the
-    function returns ``None``.
+def canonicalize_injury_type(text: str, threshold: int = 85) -> str | None:
+    """Return the canonical injury type for the given text using fuzzy matching.
+
+    The function searches ``INJURY_SYNONYM_MAP`` for any phrase in ``text`` with
+    a similarity score of at least ``threshold`` and returns the corresponding
+    key. If no match is found the function returns ``None``.
     """
     text = text.lower()
     for canonical, synonyms in INJURY_SYNONYM_MAP.items():
-        if canonical in text:
+        if canonical in text or fuzz.partial_ratio(canonical, text) >= threshold:
             return canonical
         for phrase in synonyms:
-            if phrase in text:
+            if phrase in text or fuzz.partial_ratio(phrase, text) >= threshold:
                 return canonical
     return None
 
 
-def canonicalize_location(text: str) -> str | None:
-    """Return the canonical body part for the provided text.
+def canonicalize_location(text: str, threshold: int = 85) -> str | None:
+    """Return the canonical body part for the provided text using fuzzy matching.
 
     ``LOCATION_MAP`` holds a mapping of keywords to the bank location. The
-    function searches the input text for those keywords and returns the
-    matching location. If no match is found ``None`` is returned.
+    function searches the input text for those keywords with a similarity score
+    of at least ``threshold`` and returns the matching location. If no match is
+    found ``None`` is returned.
     """
     text = text.lower()
     for key, canonical in LOCATION_MAP.items():
-        if key in text:
+        if key in text or fuzz.partial_ratio(key, text) >= threshold:
             return canonical
     return None
 

--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -1,3 +1,5 @@
+from rapidfuzz import fuzz
+
 mindset_bank = {
     "GPP": {
         "confidence": "Use future-self visualization and complete 1 small, measurable success daily to rebuild belief.",
@@ -112,8 +114,8 @@ mental_blocks = {
     ]
 }
 
-def classify_mental_block(text: str, top_n: int = 2) -> list:
-    """Classify the mental block based on input text, return top N likely matches."""
+def classify_mental_block(text: str, top_n: int = 2, threshold: int = 85) -> list:
+    """Classify the mental block using fuzzy matching and return top N likely matches."""
     if not text or not isinstance(text, str):
         return ["generic"]
 
@@ -123,7 +125,10 @@ def classify_mental_block(text: str, top_n: int = 2) -> list:
 
     scores = {}
     for block, keywords in mental_blocks.items():
-        match_count = sum(1 for kw in keywords if kw in text)
+        match_count = 0
+        for kw in keywords:
+            if kw in text or fuzz.partial_ratio(kw, text) >= threshold:
+                match_count += 1
         if match_count:
             scores[block] = match_count
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ google-api-python-client
 google-auth
 google-auth-httplib2
 google-auth-oauthlib
+rapidfuzz


### PR DESCRIPTION
## Summary
- add rapidfuzz dependency
- use fuzzy matching for injury and location parsing
- apply fuzzy matching to mental block classification

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c013a1154832ea37c558396c90d38