### PR TITLE
Implement injury text splitting helper

### DIFF
--- a/fightcamp/injury_synonyms.py
+++ b/fightcamp/injury_synonyms.py
@@ -468,3 +468,10 @@ def parse_injury_phrase(phrase: str) -> tuple[str | None, str | None]:
     injury_type = canonicalize_injury_type(cleaned)
     location = canonicalize_location(cleaned)
     return injury_type, location
+
+
+def split_injury_text(raw_text: str) -> list[str]:
+    """Normalize free-form injury text into a list of phrases."""
+    text = raw_text.lower()
+    phrases = re.split(r"(?:,|\.|;|\band\b|\bbut\b|\bthen\b|\balso\b)+", text)
+    return [p.strip() for p in phrases if p.strip()]

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import json
 
-from .injury_synonyms import parse_injury_phrase
+from .injury_synonyms import parse_injury_phrase, split_injury_text
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 # Rehab bank stores entries with fields like:
@@ -117,9 +117,7 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
     if not injury_string:
         return "\n✅ No rehab work required."
 
-    import re
-    phrases = re.split(r'[,.;&]|(?:\band\b)|(?:\bbut\b)|(?:\balso\b)', injury_string.lower())
-    injury_phrases = [p.strip() for p in phrases if p.strip()]
+    injury_phrases = split_injury_text(injury_string)
 
     parsed_entries = []
     parsed_types = []


### PR DESCRIPTION
## Summary
- add `split_injury_text` utility in `injury_synonyms`
- use the helper when generating rehab protocols

## Testing
- `python -m py_compile fightcamp/injury_synonyms.py fightcamp/rehab_protocols.py`
- `python -m py_compile fightcamp/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684c08d9d8fc832e896857b005429b0a