### PR TITLE
Remove outdated injury location field

### DIFF
--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -124,7 +124,6 @@ async def handle_submission(request: Request):
     except (TypeError, ValueError):
         training_frequency = len(training_days)
     injuries = get_value("Any injuries or areas you need to work around?", fields)
-    injury_location = get_value("Injury Location", fields).lower()
     key_goals = get_value("What are your key performance goals?", fields)
     weak_areas = get_value("Where do you feel weakest right now?", fields)
     training_preference = get_value("Do you prefer certain training styles?", fields)
@@ -183,7 +182,6 @@ async def handle_submission(request: Request):
         "days_available": len(training_days),
         "training_days": training_days,
         "injuries": normalize_list(injuries),
-        "injury_location": injury_location,
         "style_technical": raw_tech_style,
         "style_tactical": tactical_styles,
         "weaknesses": normalize_list(weak_areas),
@@ -392,7 +390,6 @@ async def handle_submission(request: Request):
         f"- Phase Days: {phase_weeks['days']['GPP']} GPP / {phase_weeks['days']['SPP']} SPP / {phase_weeks['days']['TAPER']} Taper",
         f"- Fatigue Level: {fatigue}",
         f"- Injuries: {injuries}",
-        f"- Injury Location: {injury_location}",
         f"- Training Availability: {available_days}",
         f"- Weaknesses: {weak_areas}",
         f"- Key Goals: {key_goals}",

--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -1,19 +1,16 @@
 from .rehab_protocols import REHAB_BANK, INJURY_SUPPORT_NOTES
 from .injury_synonyms import (
     parse_injury_phrase,
-    canonicalize_location,
 )
 
 
-def _fetch_injury_drills(injuries: list, location: str, phase: str) -> list:
+def _fetch_injury_drills(injuries: list, phase: str) -> list:
     """Return up to two rehab drills matching the injury info.
 
     Parameters
     ----------
     injuries:
         List of free-form injury descriptions from the intake form.
-    location:
-        Comma separated location string from the dropdown field.
     phase:
         Current training phase (``GPP``, ``SPP`` or ``TAPER``).
 
@@ -27,14 +24,6 @@ def _fetch_injury_drills(injuries: list, location: str, phase: str) -> list:
     # Build sets of canonical types and locations from all sources
     injury_types = set()
     locations = set()
-
-    if location:
-        for loc in location.split(','):
-            loc = loc.strip()
-            if not loc:
-                continue
-            canonical = canonicalize_location(loc)
-            locations.add(canonical or loc)
 
     for desc in injuries:
         itype, loc = parse_injury_phrase(desc)
@@ -104,7 +93,6 @@ def generate_recovery_block(training_context: dict) -> str:
     injuries = training_context.get("injuries", [])
     injury_drills = _fetch_injury_drills(
         injuries,
-        training_context.get("injury_location", ""),
         phase,
     )
     if injury_drills:


### PR DESCRIPTION
## Summary
- drop `Injury Location` field handling from the webhook
- update recovery drill helper to infer location solely from free text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c09e4f06c832eaf481d75edf3bd1d