### PR TITLE
Fix rehab drill duplication and remove mindset cue

### DIFF
--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -374,8 +374,6 @@ def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
         f"**Prescription:** {base_block}",
         f"**Total Exercises:** {target_exercises}",
     ]
-    if mindset_cue:
-        strength_output.append(f"**Mindset Cue:** {mindset_cue}")
     
     if fatigue_note:
         strength_output.append(f"**Adjustment:** {fatigue_note}")


### PR DESCRIPTION
## Summary
- deduplicate parsed injuries in `generate_rehab_protocols`
- avoid repeating rehab drill names
- drop the `Mindset Cue` line from strength blocks

## Testing
- `python -m py_compile fightcamp/strength.py fightcamp/rehab_protocols.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2a5c6a60832ea0f3b200397e9ae5