### PR TITLE
Improve injury text parser

### DIFF
--- a/fightcamp/injury_synonyms.py
+++ b/fightcamp/injury_synonyms.py
@@ -473,7 +473,14 @@ def parse_injury_phrase(phrase: str) -> tuple[str | None, str | None]:
 
 
 def split_injury_text(raw_text: str) -> list[str]:
-    """Normalize free-form injury text into a list of phrases."""
+    """Normalize free-form injury text into a list of phrases.
+
+    The parser splits on punctuation, common conjunctions, newlines and spaced
+    dashes so that each injury description can be processed separately.
+    """
     text = raw_text.lower()
-    phrases = re.split(r"(?:,|\.|;|\band\b|\bbut\b|\bthen\b|\balso\b)+", text)
+    phrases = re.split(
+        r"(?:,|\.|;|\n|\s[-–—]\s|\band\b|\bbut\b|\bthen\b|\balso\b)+",
+        text,
+    )
     return [p.strip() for p in phrases if p.strip()]


### PR DESCRIPTION
## Summary
- handle newlines and spaced dashes as separators in injury text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb51a0a88832ebb688f21d5bcfa1b