### PR TITLE
Enhance rehab drill matching

### DIFF
--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -47,11 +47,13 @@ def _fetch_injury_drills(injuries: list, phase: str) -> list:
         entry_type = entry.get("type", "").lower()
 
         loc_match = (
-            (entry_loc and entry_loc in locations)
+            entry_loc == "unspecified"
+            or (entry_loc and entry_loc in locations)
             or any(entry_loc in inj for inj in injuries)
         )
         type_match = (
-            (entry_type and entry_type in injury_types)
+            entry_type == "unspecified"
+            or (entry_type and entry_type in injury_types)
             or any(entry_type in inj for inj in injuries)
         )
 

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -125,7 +125,7 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
         itype, loc = parse_injury_phrase(phrase)
         if itype:
             parsed_types.append(itype)
-        if itype and loc:
+        if itype or loc:
             parsed_entries.append((itype, loc))
 
     seen_pairs = set()
@@ -154,9 +154,18 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
 
     for itype, loc in unique_entries:
         matches = [
-            entry for entry in REHAB_BANK
-            if entry.get("type") == itype
-            and entry.get("location") == loc
+            entry
+            for entry in REHAB_BANK
+            if (
+                entry.get("type") == itype
+                or entry.get("type") == "unspecified"
+                or itype is None
+            )
+            and (
+                entry.get("location") == loc
+                or entry.get("location") == "unspecified"
+                or loc is None
+            )
             and current_phase.upper() in _phases(entry)
         ]
         if matches:


### PR DESCRIPTION
## Summary
- support wildcard entries in `_fetch_injury_drills`
- allow `generate_rehab_protocols` to match drills when only injury type or location is known

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d7038e410832eb1c8f5a7da01077a