### PR TITLE
Add rehab notes to outputs

### DIFF
--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -61,9 +61,15 @@ def _fetch_injury_drills(injuries: list, phase: str) -> list:
             continue
 
         for drill in entry.get("drills", []):
-            drills.append(drill.get("name"))
-            if len(drills) >= 2:
-                return drills
+            name = drill.get("name")
+            notes = drill.get("notes")
+            if name:
+                entry_str = name
+                if notes:
+                    entry_str = f"{name} – {notes}"
+                drills.append(entry_str)
+                if len(drills) >= 2:
+                    return drills
 
     return drills
 

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -173,8 +173,13 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
             for m in matches:
                 for d in m.get("drills", []):
                     name = d.get("name")
-                    if name and name not in drills:
-                        drills.append(name)
+                    notes = d.get("notes")
+                    if name:
+                        entry = name
+                        if notes:
+                            entry = f"{name} – {notes}"
+                        if entry not in drills:
+                            drills.append(entry)
             drills = drills[:2]
             if drills:
                 lines.append(f"- {loc.title()} ({itype.title()}): {', '.join(drills)}")


### PR DESCRIPTION
## Summary
- include drill notes when generating rehab protocols
- include drill notes in recovery block rehab suggestions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da43e4a6c832eb3844ecb5a7144d9