### PR TITLE
Randomize rehab drill selection

### DIFF
--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import random
 
 from .injury_synonyms import parse_injury_phrase, split_injury_text
 
@@ -175,6 +176,7 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
                     name = d.get("name")
                     if name and name not in drills:
                         drills.append(name)
+            random.shuffle(drills)
             drills = drills[:2]
             if drills:
                 lines.append(f"- {loc.title()} ({itype.title()}): {', '.join(drills)}")


### PR DESCRIPTION
## Summary
- make rehab protocol drill selection shuffle results for variety

## Testing
- `python -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684da4983364832e9b4cd8992e048bbf