### PR TITLE
Randomize rehab drill selection

### DIFF
--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -5,7 +5,10 @@ from .injury_synonyms import (
 
 
 def _fetch_injury_drills(injuries: list, phase: str) -> list:
-    """Return up to two rehab drills matching the injury info.
+"""Return up to three rehab drills matching the injury info.
+
+If the injury type or location is unspecified the list is capped at two drills
+to avoid overly generic suggestions.
 
     Parameters
     ----------
@@ -62,7 +65,10 @@ def _fetch_injury_drills(injuries: list, phase: str) -> list:
 
         for drill in entry.get("drills", []):
             drills.append(drill.get("name"))
-            if len(drills) >= 2:
+            limit = 3
+            if entry_type == "unspecified" or entry_loc == "unspecified":
+                limit = 2
+            if len(drills) >= limit:
                 return drills
 
     return drills

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import random
 
 from .injury_synonyms import parse_injury_phrase, split_injury_text
 
@@ -175,7 +176,11 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
                     name = d.get("name")
                     if name and name not in drills:
                         drills.append(name)
-            drills = drills[:2]
+            random.shuffle(drills)
+            max_drills = 3
+            if itype in {None, "unspecified"} or loc in {None, "unspecified"}:
+                max_drills = 2
+            drills = drills[:max_drills]
             if drills:
                 lines.append(f"- {loc.title()} ({itype.title()}): {', '.join(drills)}")
     if not lines:


### PR DESCRIPTION
## Summary
- make rehab protocol drill selection shuffle results for variety
- allow up to 3 rehab drills (2 when injury info is unspecified)

## Testing
- `python -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684da4983364832e9b4cd8992e048bbf