### PR TITLE
Fix JSON decoding by stripping comments

### DIFF
--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -1,6 +1,21 @@
 from pathlib import Path
 import json
 
+
+def _load_json_strip_comments(path: Path):
+    """Load JSON file while ignoring lines that start with '//' comments."""
+    text = path.read_text()
+    cleaned_lines = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            continue
+        # Remove trailing comments on the same line if they exist
+        if "//" in stripped:
+            line = line[: line.index("//")]
+        cleaned_lines.append(line)
+    return json.loads("\n".join(cleaned_lines))
+
 from .injury_synonyms import parse_injury_phrase, split_injury_text
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
@@ -14,7 +29,7 @@ DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 #         {"name": "...", "notes": "..."}
 #     ]
 # }
-REHAB_BANK = json.loads((DATA_DIR / "rehab_bank.json").read_text())
+REHAB_BANK = _load_json_strip_comments(DATA_DIR / "rehab_bank.json")
 
 INJURY_TYPES = [
     "sprain",


### PR DESCRIPTION
## Summary
- handle JSON comments inside `rehab_bank.json`
- create helper to strip comment lines before parsing

## Testing
- `python -m fightcamp.main` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684dad027588832e8881d165e509fc58