### PR TITLE
Fix ACL rehab parsing and improve formatting

### DIFF
--- a/fightcamp/injury_synonyms.py
+++ b/fightcamp/injury_synonyms.py
@@ -10,7 +10,9 @@ INJURY_SYNONYM_MAP = {
         "out of socket", "popped out", "click out", "shift out", "unhinged",
         "grade 1", "grade 2", "grade 3", "hyperextend", "overstretched", "overextension",
         "stretched ligament", "torn ligament", "ruptured ligament", "blown ligament",
-        "sprain", "sprained", "inversion", "eversion", "rolled over", "turned over"
+        "sprain", "sprained", "inversion", "eversion", "rolled over", "turned over",
+        "acl", "acl tear", "acl injury", "acl surgery", "acl reconstruction",
+        "acl rehab"
     ],
 
     # Muscle/Tendon - every possible pull/tear description

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -199,7 +199,8 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
             if drills:
                 loc_title = loc.title() if loc else "Unspecified"
                 type_title = itype.title() if itype else "Unspecified"
-                lines.append(f"- {loc_title} ({type_title}): {', '.join(drills)}")
+                lines.append(f"- {loc_title} ({type_title}):")
+                lines.extend([f"  • {d}" for d in drills])
     if not lines:
         return "\n⚠️ No rehab options for this phase."
 


### PR DESCRIPTION
## Summary
- parse ACL-related text as a sprain
- format rehab protocol output with bullet points for each drill

## Testing
- `python -m py_compile fightcamp/rehab_protocols.py fightcamp/injury_synonyms.py`

------
https://chatgpt.com/codex/tasks/task_e_684db595a8e0832e99b5a6afdda51136