### PR TITLE
Streamline rehab by deduping body parts

### DIFF
--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -144,11 +144,17 @@ def generate_rehab_protocols(*, injury_string: str, exercise_data: list, current
             parsed_entries.append((itype, loc))
 
     seen_pairs = set()
+    seen_locations = set()
     unique_entries = []
     for pair in parsed_entries:
-        if pair not in seen_pairs:
-            seen_pairs.add(pair)
-            unique_entries.append(pair)
+        itype, loc = pair
+        if pair in seen_pairs:
+            continue
+        if loc in seen_locations:
+            continue
+        seen_pairs.add(pair)
+        seen_locations.add(loc)
+        unique_entries.append(pair)
 
     flagged = []
     for injury in injury_phrases:


### PR DESCRIPTION
## Summary
- avoid duplicate rehab entries for the same body part

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python notes/rehab_injury_types.py > /tmp/rehab_types.txt && tail -n 5 /tmp/rehab_types.txt`


------
https://chatgpt.com/codex/tasks/task_e_684dbcf836fc832eb71a29aeeb671701