### PR TITLE
Fix local data path and credential handling

### DIFF
--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -64,30 +64,30 @@ WEAKNESS_NORMALIZER = {
 }
 
 # Auth setup
-b64_creds = os.getenv("GOOGLE_CREDS_B64")
-if b64_creds:
-    with open("clientsecrettallyso.json", "w") as f:
-        decoded = base64.b64decode(b64_creds)
-        f.write(decoded.decode("utf-8"))
-SERVICE_ACCOUNT_FILE = "clientsecrettallyso.json"
-SCOPES = [
-    "https://www.googleapis.com/auth/documents",
-    "https://www.googleapis.com/auth/drive",
-]
+try:
+    b64_creds = os.getenv("GOOGLE_CREDS_B64")
+    if b64_creds:
+        with open("clientsecrettallyso.json", "w") as f:
+            decoded = base64.b64decode(b64_creds)
+            f.write(decoded.decode("utf-8"))
+    SERVICE_ACCOUNT_FILE = "clientsecrettallyso.json"
+    SCOPES = [
+        "https://www.googleapis.com/auth/documents",
+        "https://www.googleapis.com/auth/drive",
+    ]
 
-if service_account and build:
-    try:
+    if service_account and build:
         creds = service_account.Credentials.from_service_account_file(
             SERVICE_ACCOUNT_FILE, scopes=SCOPES
         )
         docs_service = build("docs", "v1", credentials=creds)
         drive_service = build("drive", "v3", credentials=creds)
-    except Exception as e:
+    else:
         docs_service = drive_service = None
-        print("⚠️  Google credentials not found; docs export disabled.", e)
-else:
+        print("⚠️  Google libraries missing; docs export disabled.")
+except Exception as e:
     docs_service = drive_service = None
-    print("⚠️  Google libraries missing; docs export disabled.")
+    print("⚠️  Google credentials not found; docs export disabled.", e)
 
 def get_value(label, fields):
     for field in fields:
@@ -477,8 +477,7 @@ async def generate_plan(data: dict):
 
 
 def main():
-    root = Path(__file__).resolve().parents[1]
-    data_file = root / "test_data.json"
+    data_file = Path("test_data.json").resolve()
     if not data_file.exists():
         raise FileNotFoundError(f"Test data file not found: {data_file}")
     with open(data_file, "r") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ google-auth
 google-auth-httplib2
 google-auth-oauthlib
 rapidfuzz
+gspread
+oauth2client


### PR DESCRIPTION
## Summary
- load Google credentials in a try/except block
- update `main()` to look for `test_data.json` from repo root
- add missing packages to requirements for CI

## Testing
- `python fightcamp/main.py` *(fails: attempted relative import)*
- `python -m fightcamp.main` *(fails: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684dce9d135c832e91342e5a094d9bde