### PR TITLE
Support multiple technical styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Run the application with `python -m fightcamp.main` from the project root.
 
 Recent updates removed the OpenAI dependency and now build plans entirely from the module outputs. Short-camp handling and style-specific rules still adjust the phase weeks correctly via the helper `_apply_style_rules()`.
 
+The **Fighting Style (Technical)** field accepts a comma-separated list when an athlete has more than one technical base (e.g. `boxing, wrestling`). The style that appears first in this list sets the fight format while conditioning drills consider every style provided.
+
 ### Professional Status
 
 Setting the **Professional Status** field to `pro` or `professional` adjusts the camp ratios when the camp is four weeks or longer. The shift from GPP to SPP depends on fatigue, weight cutting and mindset:

--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -132,7 +132,7 @@ async def generate_plan(data: dict):
 
     # Extract and normalize fields
     def normalize_list(field):
-        return [w.strip().lower() for w in field.split(",")] if field else []
+        return [w.strip().lower() for w in field.split(",") if w.strip()] if field else []
 
     full_name = get_value("Full name", fields)
     age = get_value("Age", fields)
@@ -186,8 +186,10 @@ async def generate_plan(data: dict):
         "grappler": "mma",
         "karate": "kickboxing"
     }
-    raw_tech_style = fighting_style_technical.strip().lower()
-    mapped_format = style_map.get(raw_tech_style, "mma")
+    # First style in the list determines fight format
+    tech_styles = normalize_list(fighting_style_technical)
+    primary_tech = tech_styles[0] if tech_styles else ""
+    mapped_format = style_map.get(primary_tech, "mma")
     tactical_styles = normalize_list(fighting_style_tactical)
     if stance.strip().lower() == "hybrid" and "hybrid" not in tactical_styles:
         tactical_styles.append("hybrid")
@@ -217,7 +219,7 @@ async def generate_plan(data: dict):
         "days_available": len(training_days),
         "training_days": training_days,
         "injuries": normalize_list(injuries),
-        "style_technical": raw_tech_style,
+        "style_technical": tech_styles,
         "style_tactical": tactical_styles,
         "weaknesses": [
             tag


### PR DESCRIPTION
## Summary
- allow comma-separated technical styles
- process technical style lists in conditioning generator
- document multi-style input in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*


------
https://chatgpt.com/codex/tasks/task_e_684dd1b555f8832ebb8e62a421243126