### PR TITLE
Fix rehab duplication and equipment bug

### DIFF
--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -619,6 +619,8 @@ def generate_conditioning_block(flags):
         for d in drills:
             name = d.get("name", "Unnamed Drill")
             equipment = d.get("equipment", [])
+            if isinstance(equipment, str):
+                equipment = [equipment]
             extra_eq = [e for e in equipment if e.lower() not in name.lower()]
             if extra_eq:
                 name = f"{name} ({', '.join(extra_eq)})"
@@ -644,10 +646,5 @@ def generate_conditioning_block(flags):
             output_lines.append(f"  • Purpose: {purpose}")
             output_lines.append(f"  • ⚠️ Red Flags: {d.get('red_flags', 'None')}")
 
-
-    if fatigue == "high":
-        output_lines.append("\n⚠️ High fatigue detected – conditioning volume reduced.")
-    elif fatigue == "moderate":
-        output_lines.append("\n⚠️ Moderate fatigue – monitor recovery and hydration closely.")
 
     return "\n".join(output_lines), selected_drill_names


### PR DESCRIPTION
## Summary
- prevent string equipment from producing stray characters in conditioning blocks
- consolidate rehab notes across phases and filter duplicate drills
- add generalized injury support notes and include them once in the plan

## Testing
- `python -m py_compile fightcamp/*.py`
- `python -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684df86db228832e9ba5ada7f32cb51b