### PR TITLE
Remove duplicate injury recovery info

### DIFF
--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -68,10 +68,10 @@ def _fetch_injury_drills(injuries: list, phase: str) -> list:
                 if notes:
                     entry_str = f"{name} – {notes}"
                 drills.append(entry_str)
-                if len(drills) >= 3:
+                if len(drills) >= 2:
                     return drills
 
-    return drills
+    return drills[:2]
 
 
 def generate_recovery_block(training_context: dict) -> str:
@@ -99,22 +99,7 @@ def generate_recovery_block(training_context: dict) -> str:
     ]
 
     injuries = training_context.get("injuries", [])
-    injury_drills = _fetch_injury_drills(
-        injuries,
-        phase,
-    )
-    if injury_drills:
-        recovery_block.append("\n**Injury-Specific Drills:**")
-        recovery_block += [f"- {d}" for d in injury_drills]
-
-    # Add injury-specific support tips
-    done_types = set()
-    for desc in injuries:
-        itype, _ = parse_injury_phrase(desc)
-        if itype and itype in INJURY_SUPPORT_NOTES and itype not in done_types:
-            done_types.add(itype)
-            recovery_block.append(f"\n**{itype.title()} Support Notes:**")
-            recovery_block += [f"- {t}" for t in INJURY_SUPPORT_NOTES[itype]]
+    _ = injuries  # injuries currently unused; rehab protocols handle specifics
 
     # Age-based Adjustments
     if age_risk:

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -172,6 +172,13 @@ def generate_rehab_protocols(
         if itype or loc:
             parsed_entries.append((itype, loc))
 
+    # Prioritize specific injuries over unspecified duplicates
+    parsed_entries.sort(key=lambda x: (x[0] is None or x[0] == "unspecified"))
+
+    # Drop injuries without a body part when at least one body part was found
+    if any(loc for _, loc in parsed_entries):
+        parsed_entries = [p for p in parsed_entries if p[1] is not None]
+
     seen_pairs = set()
     seen_locations = set()
     unique_entries = []
@@ -246,7 +253,7 @@ def generate_rehab_protocols(
                         if entry not in seen_drills:
                             drills.append(entry)
                             seen_drills.add(entry)
-            drills = drills[:3]
+            drills = drills[:2]
             if drills:
                 loc_title = loc.title() if loc else "Unspecified"
                 type_title = itype.title() if itype else "Unspecified"


### PR DESCRIPTION
## Summary
- limit `_fetch_injury_drills` to 2 suggestions
- drop injury-specific drills and notes from the recovery block
- filter generic injury entries and cut rehab drills to 2

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m fightcamp.main test_data.json` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684e0240335c832e9e43fe0ac17b2a73