### PR TITLE
Split rehab bank into single phase entries

### DIFF
--- a/data/rehab_bank_split.json
+++ b/data/rehab_bank_split.json
@@ -1,0 +1,22497 @@
+[
+  {
+    "location": "ankle",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "GPP",
+        "notes": "Rebuild proprioception"
+      },
+      {
+        "name": "Banded Ankle Circles",
+        "phase": "GPP",
+        "notes": "Restore multi-directional control"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "SPP",
+        "notes": "Progress to dynamic balance under fatigue"
+      },
+      {
+        "name": "Banded Ankle Circles",
+        "phase": "SPP",
+        "notes": "Add resistance for joint reactivity"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Toe Curls)",
+        "phase": "GPP",
+        "notes": "Activate toe flexors and arch"
+      },
+      {
+        "name": "Bottom-Up Kettlebell Hold (Toe Loaded)",
+        "phase": "GPP",
+        "notes": "Restore control"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Toe Curls)",
+        "phase": "SPP",
+        "notes": "Add towel weight or reps"
+      },
+      {
+        "name": "Bottom-Up Kettlebell Hold (Toe Loaded)",
+        "phase": "SPP",
+        "notes": "Reinforce toe stability in loaded posture"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Pogo Jumps",
+        "phase": "SPP",
+        "notes": "Rebuild spring and rebound"
+      },
+      {
+        "name": "Toe Off Isometric Presses",
+        "phase": "SPP",
+        "notes": "Load toe under static extension"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "sprain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Double-Leg Pogo Jumps",
+        "phase": "TAPER",
+        "notes": "Maintain SSC sharpness with low volume"
+      },
+      {
+        "name": "Toe Off Isometric Presses",
+        "phase": "TAPER",
+        "notes": "Use short bursts pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Short Foot Doming",
+        "phase": "GPP",
+        "notes": "Rebuild arch activation"
+      },
+      {
+        "name": "Toe Spreads with Band",
+        "phase": "GPP",
+        "notes": "Mobilize transverse arch"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Short Foot Doming",
+        "phase": "SPP",
+        "notes": "Progress to standing or loaded stances"
+      },
+      {
+        "name": "Toe Spreads with Band",
+        "phase": "SPP",
+        "notes": "Add tempo or band tension"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Knee-Locked Calf Stretch",
+        "phase": "GPP",
+        "notes": "Restore length to fascia line"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Arch to Heel",
+        "phase": "GPP",
+        "notes": "Break up tension points"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Knee-Locked Calf Stretch",
+        "phase": "SPP",
+        "notes": "Maintain under load"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Arch to Heel",
+        "phase": "SPP",
+        "notes": "Post-drill flush"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Knee-Locked Calf Stretch",
+        "phase": "TAPER",
+        "notes": "Use short holds post-session"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Arch to Heel",
+        "phase": "TAPER",
+        "notes": "Morning priming tool"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Heel Taps on Soft Mat",
+        "phase": "GPP",
+        "notes": "Rebuild sensory tolerance"
+      },
+      {
+        "name": "Heel Taps on Soft Mat",
+        "phase": "GPP",
+        "notes": "Light progression to walking load"
+      },
+      {
+        "name": "Foam Pad Heel Rolls",
+        "phase": "GPP",
+        "notes": "Improve pressure dispersion"
+      },
+      {
+        "name": "Foam Pad Heel Rolls",
+        "phase": "GPP",
+        "notes": "Advance to barefoot load steps"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Toe-Elevated Calf Raises",
+        "phase": "SPP",
+        "notes": "Strengthen fascia in stretch"
+      },
+      {
+        "name": "Toe-Elevated Calf Raises",
+        "phase": "SPP",
+        "notes": "Add slow eccentric tempo"
+      },
+      {
+        "name": "Toe Pulls with Band",
+        "phase": "SPP",
+        "notes": "Train fascia end-range"
+      },
+      {
+        "name": "Toe Pulls with Band",
+        "phase": "SPP",
+        "notes": "Build foot tolerance during strikes"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Calf Stretch (Straight Leg)",
+        "phase": "TAPER",
+        "notes": "Drain posterior tightness"
+      },
+      {
+        "name": "Wall Calf Stretch (Straight Leg)",
+        "phase": "TAPER",
+        "notes": "Restore range pre-fight"
+      },
+      {
+        "name": "Elevated Heel Pumps",
+        "phase": "TAPER",
+        "notes": "Promote circulation"
+      },
+      {
+        "name": "Elevated Heel Pumps",
+        "phase": "TAPER",
+        "notes": "Use between drills or post-session"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg RDL with Reach",
+        "phase": "SPP",
+        "notes": "Build control under movement"
+      },
+      {
+        "name": "Barefoot Lateral Hops",
+        "phase": "SPP",
+        "notes": "Test quick contact control"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Single-Leg RDL with Reach",
+        "phase": "TAPER",
+        "notes": "Keep pattern with low load"
+      },
+      {
+        "name": "Barefoot Lateral Hops",
+        "phase": "TAPER",
+        "notes": "Reduce distance but keep speed"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Spreading with Resistance Band",
+        "phase": "GPP",
+        "notes": "Loosen foot structures"
+      },
+      {
+        "name": "Lacrosse Ball Roll \u2013 Arch to Base",
+        "phase": "GPP",
+        "notes": "Break up adhesions"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Toe Spreading with Resistance Band",
+        "phase": "TAPER",
+        "notes": "Maintain mobility for balance"
+      },
+      {
+        "name": "Lacrosse Ball Roll \u2013 Arch to Base",
+        "phase": "TAPER",
+        "notes": "Use daily pre-warmup"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foot Massage with Lacrosse Ball",
+        "phase": "TAPER",
+        "notes": "Decrease residual tension"
+      },
+      {
+        "name": "Foot Massage with Lacrosse Ball",
+        "phase": "TAPER",
+        "notes": "Use nightly or post-conditioning"
+      },
+      {
+        "name": "Pedal Flush \u2013 Reverse Bike Low Intensity",
+        "phase": "TAPER",
+        "notes": "Light recovery flush"
+      },
+      {
+        "name": "Pedal Flush \u2013 Reverse Bike Low Intensity",
+        "phase": "TAPER",
+        "notes": "Maintain oxygen to tissue"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Distraction",
+        "phase": "GPP",
+        "notes": "Create space in front joint"
+      },
+      {
+        "name": "Loaded Knee-Over-Toe Lunge",
+        "phase": "GPP",
+        "notes": "Control dorsiflexion"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Distraction",
+        "phase": "SPP",
+        "notes": "Use pre-lift to clear pinch"
+      },
+      {
+        "name": "Loaded Knee-Over-Toe Lunge",
+        "phase": "SPP",
+        "notes": "Increase ROM through full range"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Loaded Dorsiflexion Rocks (Barbell Front Foot)",
+        "phase": "SPP",
+        "notes": "Open ankle range"
+      },
+      {
+        "name": "Massage Gun \u2013 Anterior Line",
+        "phase": "SPP",
+        "notes": "Release tight tibialis"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Loaded Dorsiflexion Rocks (Barbell Front Foot)",
+        "phase": "TAPER",
+        "notes": "Use in taper for glide maintenance"
+      },
+      {
+        "name": "Massage Gun \u2013 Anterior Line",
+        "phase": "TAPER",
+        "notes": "Short bursts pre-drill"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Ankle Pumps",
+        "phase": "TAPER",
+        "notes": "Pump lymphatic fluid"
+      },
+      {
+        "name": "Elevated Ankle Pumps",
+        "phase": "TAPER",
+        "notes": "Use in cooldown to reduce flare"
+      },
+      {
+        "name": "Wall Ankle Circles (No Load)",
+        "phase": "TAPER",
+        "notes": "Gentle ROM recovery"
+      },
+      {
+        "name": "Wall Ankle Circles (No Load)",
+        "phase": "TAPER",
+        "notes": "Keep joint active under zero stress"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Rebuild capsule range"
+      },
+      {
+        "name": "Band Toe Pulls \u2013 End Range",
+        "phase": "GPP",
+        "notes": "Control full motion"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Toe CARs (Controlled Articular Rotations)",
+        "phase": "TAPER",
+        "notes": "Maintain full ROM pre-fight"
+      },
+      {
+        "name": "Band Toe Pulls \u2013 End Range",
+        "phase": "TAPER",
+        "notes": "Reinforce control under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Big Toe Press into Ground",
+        "phase": "SPP",
+        "notes": "Load without movement"
+      },
+      {
+        "name": "Toe Flexor Resistance Band Pulls",
+        "phase": "SPP",
+        "notes": "Rebuild control"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Big Toe Press into Ground",
+        "phase": "TAPER",
+        "notes": "Use light holds to retain signal"
+      },
+      {
+        "name": "Toe Flexor Resistance Band Pulls",
+        "phase": "TAPER",
+        "notes": "Low fatigue, low movement"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Towel Slides (Loaded Variant)",
+        "phase": "GPP",
+        "notes": "Restore flexor glide"
+      },
+      {
+        "name": "Manual Toe Flexor Resistance (Band)",
+        "phase": "GPP",
+        "notes": "Build isolated tension"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Toe Towel Slides (Loaded Variant)",
+        "phase": "SPP",
+        "notes": "Increase tempo or pause"
+      },
+      {
+        "name": "Manual Toe Flexor Resistance (Band)",
+        "phase": "SPP",
+        "notes": "Add continuous reps"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Toe Extensor Stretch (Wall Dorsiflex)",
+        "phase": "TAPER",
+        "notes": "Downregulate toe tension"
+      },
+      {
+        "name": "Toe Extensor Stretch (Wall Dorsiflex)",
+        "phase": "TAPER",
+        "notes": "Use post-session or AM"
+      },
+      {
+        "name": "Band-Assisted Toe Extension Hold",
+        "phase": "TAPER",
+        "notes": "Maintain smooth end range"
+      },
+      {
+        "name": "Band-Assisted Toe Extension Hold",
+        "phase": "TAPER",
+        "notes": "Low load activation"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Lateral Hop-Stick Drill",
+        "phase": "SPP",
+        "notes": "Train reactive ankle control"
+      },
+      {
+        "name": "Foam Pad Jump-Stick",
+        "phase": "SPP",
+        "notes": "Improve soft landing control"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lateral Hop-Stick Drill",
+        "phase": "TAPER",
+        "notes": "Maintain sharpness with short sets"
+      },
+      {
+        "name": "Foam Pad Jump-Stick",
+        "phase": "TAPER",
+        "notes": "Use as CNS primer pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Resisted Toe Pulls with Band",
+        "phase": "GPP",
+        "notes": "Load toe flexors"
+      },
+      {
+        "name": "Mid-Foot Isometric Holds (Band Loop)",
+        "phase": "GPP",
+        "notes": "Tension through arch"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Resisted Toe Pulls with Band",
+        "phase": "SPP",
+        "notes": "Tie into sprint or strike mechanics"
+      },
+      {
+        "name": "Mid-Foot Isometric Holds (Band Loop)",
+        "phase": "SPP",
+        "notes": "Progress to timed holds or anti-rotation"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Toe Raises",
+        "phase": "GPP",
+        "notes": "Activate anterior tibialis"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Tibialis Line",
+        "phase": "GPP",
+        "notes": "Reduce inflammation and tension"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Toe Raises",
+        "phase": "SPP",
+        "notes": "Increase reps + tempo for foot strike endurance"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Tibialis Line",
+        "phase": "SPP",
+        "notes": "Use post-run to limit re-flare"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Circles \u2013 Mid-Shin",
+        "phase": "GPP",
+        "notes": "Restore tissue tolerance"
+      },
+      {
+        "name": "Tap-Drill with Soft Stick",
+        "phase": "GPP",
+        "notes": "Gradually reintroduce impact"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Foam Roller Circles \u2013 Mid-Shin",
+        "phase": "SPP",
+        "notes": "Progress to kneeling or pad contact drills"
+      },
+      {
+        "name": "Tap-Drill with Soft Stick",
+        "phase": "SPP",
+        "notes": "Mimic striking contact progression"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Anterior Shin Stretch",
+        "phase": "GPP",
+        "notes": "Loosen tibialis tension"
+      },
+      {
+        "name": "Lacrosse Ball Glide \u2013 Tibialis",
+        "phase": "GPP",
+        "notes": "Break up tight adhesions"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Anterior Shin Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain front chain length post-training"
+      },
+      {
+        "name": "Lacrosse Ball Glide \u2013 Tibialis",
+        "phase": "TAPER",
+        "notes": "Use short sessions pre-spar"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Heel Walks",
+        "phase": "SPP",
+        "notes": "Train anterior chain under low impact"
+      },
+      {
+        "name": "Isometric Toe Lift Holds",
+        "phase": "SPP",
+        "notes": "Load without range"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heel Walks",
+        "phase": "TAPER",
+        "notes": "Maintain foot strike tolerance"
+      },
+      {
+        "name": "Isometric Toe Lift Holds",
+        "phase": "TAPER",
+        "notes": "Quick tension cues pre-sprint or drill"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Shin Percussion",
+        "phase": "GPP",
+        "notes": "Rebuild contact tolerance"
+      },
+      {
+        "name": "Light Shin Percussion",
+        "phase": "GPP",
+        "notes": "Use daily to desensitize tissue"
+      },
+      {
+        "name": "Wall Shin Slides",
+        "phase": "GPP",
+        "notes": "Improve joint mobility"
+      },
+      {
+        "name": "Wall Shin Slides",
+        "phase": "GPP",
+        "notes": "Add tempo or light band once contact is tolerated"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Double-Leg Calf Raises",
+        "phase": "GPP",
+        "notes": "Rebuild full range control"
+      },
+      {
+        "name": "Isometric Wall Push Hold",
+        "phase": "GPP",
+        "notes": "Tension without movement"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Calf Raises",
+        "phase": "SPP",
+        "notes": "Progress to single-leg tempo loading"
+      },
+      {
+        "name": "Isometric Wall Push Hold",
+        "phase": "SPP",
+        "notes": "Add band resistance or hold under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Calf Stretch (Bent Knee)",
+        "phase": "GPP",
+        "notes": "Target deep soleus tension"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Soleus Line",
+        "phase": "GPP",
+        "notes": "Reduce posterior tightness"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Calf Stretch (Bent Knee)",
+        "phase": "TAPER",
+        "notes": "Maintain length without CNS cost"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Soleus Line",
+        "phase": "TAPER",
+        "notes": "Use after sparring or jumps"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Tip-Toe Wall Press",
+        "phase": "SPP",
+        "notes": "Improve endurance under tension"
+      },
+      {
+        "name": "Active Band Calf Pumps",
+        "phase": "SPP",
+        "notes": "Stimulate blood flow cycles"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Tip-Toe Wall Press",
+        "phase": "TAPER",
+        "notes": "Maintain contraction without volume"
+      },
+      {
+        "name": "Active Band Calf Pumps",
+        "phase": "TAPER",
+        "notes": "Low-fatigue use in cooldown"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "GPP",
+        "notes": "Build tendon load capacity"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "GPP",
+        "notes": "Decrease stiffness"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "SPP",
+        "notes": "Increase depth or tempo"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "SPP",
+        "notes": "Use daily post-loading"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "TAPER",
+        "notes": "Maintain function"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "TAPER",
+        "notes": "Maintain glide pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Holds in Tip-Toe",
+        "phase": "SPP",
+        "notes": "Load tendon without movement"
+      },
+      {
+        "name": "Banded Heel Push with Hold",
+        "phase": "SPP",
+        "notes": "Strengthen in shortened position"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Holds in Tip-Toe",
+        "phase": "TAPER",
+        "notes": "Pre-drill activation"
+      },
+      {
+        "name": "Banded Heel Push with Hold",
+        "phase": "TAPER",
+        "notes": "Use as low-fade neural primer"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (TKEs)",
+        "phase": "GPP",
+        "notes": "Target VMO"
+      },
+      {
+        "name": "Massage Gun \u2013 Quad Sweep to Patella",
+        "phase": "GPP",
+        "notes": "Reduce tracking tension"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (TKEs)",
+        "phase": "SPP",
+        "notes": "Increase band load or reps"
+      },
+      {
+        "name": "Massage Gun \u2013 Quad Sweep to Patella",
+        "phase": "SPP",
+        "notes": "Use after TKE or compound lifts"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quad & Hip Flexor Stretch",
+        "phase": "GPP",
+        "notes": "Loosen anterior chain"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Line",
+        "phase": "GPP",
+        "notes": "Clear quad tone"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Quad & Hip Flexor Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain extension without CNS load"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Line",
+        "phase": "TAPER",
+        "notes": "Use 30s glides before skill drills"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Sit (Short Arc)",
+        "phase": "GPP",
+        "notes": "Low flexion quad load"
+      },
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "GPP",
+        "notes": "Stabilize tracking"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Sit (Short Arc)",
+        "phase": "SPP",
+        "notes": "Increase depth or add ball squeeze"
+      },
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "SPP",
+        "notes": "Progress to dynamic tempo sets"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lateral Step-Downs",
+        "phase": "GPP",
+        "notes": "Train valgus control"
+      },
+      {
+        "name": "Band-Assisted Lateral Lunges",
+        "phase": "GPP",
+        "notes": "Keep range safe"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Lateral Step-Downs",
+        "phase": "SPP",
+        "notes": "Add range or load with dumbbell"
+      },
+      {
+        "name": "Band-Assisted Lateral Lunges",
+        "phase": "SPP",
+        "notes": "Remove band or increase tempo"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Shuffles (Partial Squat)",
+        "phase": "GPP",
+        "notes": "Activate glute medius"
+      },
+      {
+        "name": "Isometric Spanish Squat (30\u00b0 Flexion)",
+        "phase": "GPP",
+        "notes": "Reduce patellar stress"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Shuffles (Partial Squat)",
+        "phase": "SPP",
+        "notes": "Add deceleration cues (e.g., soft landing)"
+      },
+      {
+        "name": "Isometric Spanish Squat (30\u00b0 Flexion)",
+        "phase": "SPP",
+        "notes": "Add pulses or band resistance"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sliding Hamstring Curls (Sliders/Towel)",
+        "phase": "GPP",
+        "notes": "Eccentric focus"
+      },
+      {
+        "name": "Seated Knee Extension (Hold at 60\u00b0)",
+        "phase": "GPP",
+        "notes": "Quad activation without compression"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Sliding Hamstring Curls (Sliders/Towel)",
+        "phase": "TAPER",
+        "notes": "Reduce volume, maintain neuromuscular control"
+      },
+      {
+        "name": "Seated Knee Extension (Hold at 60\u00b0)",
+        "phase": "TAPER",
+        "notes": "Lighten load, emphasize form"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Step-Downs (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "3s lowering phase"
+      },
+      {
+        "name": "Pogo Hops (Low Amplitude)",
+        "phase": "GPP",
+        "notes": "Reintroduce plyometrics"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Step-Downs (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Add lateral or rotational component"
+      },
+      {
+        "name": "Pogo Hops (Low Amplitude)",
+        "phase": "SPP",
+        "notes": "Progress to directional changes"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "VMO Activation Off Bench (Leg Extension Hold)",
+        "phase": "GPP",
+        "notes": "Isometric at 30\u00b0"
+      },
+      {
+        "name": "Quadruped Tibial Glides (Band-Assisted)",
+        "phase": "GPP",
+        "notes": "Improve joint mobility"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "VMO Activation Off Bench (Leg Extension Hold)",
+        "phase": "SPP",
+        "notes": "Add ankle weights"
+      },
+      {
+        "name": "Quadruped Tibial Glides (Band-Assisted)",
+        "phase": "SPP",
+        "notes": "Integrate with crawling patterns"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Couch Stretch + Tibial Rotation",
+        "phase": "TAPER",
+        "notes": "Combine quad/hip flexor mobility with knee joint play"
+      },
+      {
+        "name": "Low-Load Blood Flow Restriction (BFR) Leg Extensions",
+        "phase": "TAPER",
+        "notes": "20% 1RM, high reps (30-15-15-15) to maintain tissue resilience"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Isometric Wall Sit (60\u00b0 Flexion)",
+        "phase": "GPP",
+        "notes": "Build endurance"
+      },
+      {
+        "name": "Single-Leg Balance with Tibial Rotation",
+        "phase": "GPP",
+        "notes": "Improve proprioception"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Isometric Wall Sit (60\u00b0 Flexion)",
+        "phase": "SPP",
+        "notes": "Add contralateral leg swings or band resistance"
+      },
+      {
+        "name": "Single-Leg Balance with Tibial Rotation",
+        "phase": "SPP",
+        "notes": "Progress to unstable surface (foam pad)"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Step-Up Hold (Mid-Range)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Single-Leg Mini-Band Terminal Knee Extension",
+        "phase": "GPP",
+        "notes": "Isolate VMO"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Step-Up Hold (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Add explosive concentric phase"
+      },
+      {
+        "name": "Single-Leg Mini-Band Terminal Knee Extension",
+        "phase": "SPP",
+        "notes": "Integrate into lateral movement patterns"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Eccentric Decline Squat (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Control deceleration"
+      },
+      {
+        "name": "Isometric Quadruped Knee Flexion Hold",
+        "phase": "GPP",
+        "notes": "Hamstring activation"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Single-Leg Eccentric Decline Squat (3s Lowering)",
+        "phase": "TAPER",
+        "notes": "Reduce depth, emphasize form"
+      },
+      {
+        "name": "Isometric Quadruped Knee Flexion Hold",
+        "phase": "TAPER",
+        "notes": "Short holds pre-competition"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Spanish Squat (Isometric)",
+        "phase": "GPP",
+        "notes": "Reduce patellar load"
+      },
+      {
+        "name": "Isometric Single-Leg Bridge (Knee Extended)",
+        "phase": "GPP",
+        "notes": "Glute-hamstring synergy"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Spanish Squat (Isometric)",
+        "phase": "SPP",
+        "notes": "Add pulse contractions"
+      },
+      {
+        "name": "Isometric Single-Leg Bridge (Knee Extended)",
+        "phase": "SPP",
+        "notes": "Add marching variation"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Single-Leg Wall Lean (30s)",
+        "phase": "TAPER",
+        "notes": "Maintain tension without fatigue"
+      },
+      {
+        "name": "Single-Leg Balance with Eyes Closed",
+        "phase": "TAPER",
+        "notes": "Reinforce neural pathways pre-competition"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "SPP",
+        "notes": "Reinforce lateral control"
+      },
+      {
+        "name": "Reactive Knee Bounces (Foam Pad)",
+        "phase": "SPP",
+        "notes": "Improve balance under contact"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "TAPER",
+        "notes": "Keep pattern sharp pre-fight"
+      },
+      {
+        "name": "Reactive Knee Bounces (Foam Pad)",
+        "phase": "TAPER",
+        "notes": "Use for CNS reactivity in taper"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Toe Raises",
+        "phase": "GPP",
+        "notes": "Activate anterior tibialis"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Tibialis Line",
+        "phase": "GPP",
+        "notes": "Reduce inflammation and tension"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Toe Raises",
+        "phase": "SPP",
+        "notes": "Increase reps + tempo for foot strike endurance"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Tibialis Line",
+        "phase": "SPP",
+        "notes": "Use post-run to limit re-flare"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Circles \u2013 Mid-Shin",
+        "phase": "GPP",
+        "notes": "Restore tissue tolerance"
+      },
+      {
+        "name": "Tap-Drill with Soft Stick",
+        "phase": "GPP",
+        "notes": "Gradually reintroduce impact"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Foam Roller Circles \u2013 Mid-Shin",
+        "phase": "SPP",
+        "notes": "Progress to kneeling or pad contact drills"
+      },
+      {
+        "name": "Tap-Drill with Soft Stick",
+        "phase": "SPP",
+        "notes": "Mimic striking contact progression"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Anterior Shin Stretch",
+        "phase": "GPP",
+        "notes": "Loosen tibialis tension"
+      },
+      {
+        "name": "Lacrosse Ball Glide \u2013 Tibialis",
+        "phase": "GPP",
+        "notes": "Break up tight adhesions"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Anterior Shin Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain front chain length post-training"
+      },
+      {
+        "name": "Lacrosse Ball Glide \u2013 Tibialis",
+        "phase": "TAPER",
+        "notes": "Use short sessions pre-spar"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Heel Walks",
+        "phase": "SPP",
+        "notes": "Train anterior chain under low impact"
+      },
+      {
+        "name": "Isometric Toe Lift Holds",
+        "phase": "SPP",
+        "notes": "Load without range"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heel Walks",
+        "phase": "TAPER",
+        "notes": "Maintain foot strike tolerance"
+      },
+      {
+        "name": "Isometric Toe Lift Holds",
+        "phase": "TAPER",
+        "notes": "Quick tension cues pre-sprint or drill"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Shin Percussion",
+        "phase": "GPP",
+        "notes": "Rebuild contact tolerance"
+      },
+      {
+        "name": "Light Shin Percussion",
+        "phase": "GPP",
+        "notes": "Use daily to desensitize tissue"
+      },
+      {
+        "name": "Wall Shin Slides",
+        "phase": "GPP",
+        "notes": "Improve joint mobility"
+      },
+      {
+        "name": "Wall Shin Slides",
+        "phase": "GPP",
+        "notes": "Add tempo or light band once contact is tolerated"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Double-Leg Calf Raises",
+        "phase": "GPP",
+        "notes": "Rebuild full range control"
+      },
+      {
+        "name": "Isometric Wall Push Hold",
+        "phase": "GPP",
+        "notes": "Tension without movement"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Calf Raises",
+        "phase": "SPP",
+        "notes": "Progress to single-leg tempo loading"
+      },
+      {
+        "name": "Isometric Wall Push Hold",
+        "phase": "SPP",
+        "notes": "Add band resistance or hold under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Calf Stretch (Bent Knee)",
+        "phase": "GPP",
+        "notes": "Target deep soleus tension"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Soleus Line",
+        "phase": "GPP",
+        "notes": "Reduce posterior tightness"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Calf Stretch (Bent Knee)",
+        "phase": "TAPER",
+        "notes": "Maintain length without CNS cost"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Soleus Line",
+        "phase": "TAPER",
+        "notes": "Use after sparring or jumps"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Tip-Toe Wall Press",
+        "phase": "SPP",
+        "notes": "Improve endurance under tension"
+      },
+      {
+        "name": "Active Band Calf Pumps",
+        "phase": "SPP",
+        "notes": "Stimulate blood flow cycles"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Tip-Toe Wall Press",
+        "phase": "TAPER",
+        "notes": "Maintain contraction without volume"
+      },
+      {
+        "name": "Active Band Calf Pumps",
+        "phase": "TAPER",
+        "notes": "Low-fatigue use in cooldown"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "GPP",
+        "notes": "Build tendon load capacity"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "GPP",
+        "notes": "Decrease stiffness"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "SPP",
+        "notes": "Increase depth or tempo"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "SPP",
+        "notes": "Use daily post-loading"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Calf Drops on Step",
+        "phase": "TAPER",
+        "notes": "Maintain function"
+      },
+      {
+        "name": "Massage Gun \u2013 Achilles Line",
+        "phase": "TAPER",
+        "notes": "Maintain glide pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Holds in Tip-Toe",
+        "phase": "SPP",
+        "notes": "Load tendon without movement"
+      },
+      {
+        "name": "Banded Heel Push with Hold",
+        "phase": "SPP",
+        "notes": "Strengthen in shortened position"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Holds in Tip-Toe",
+        "phase": "TAPER",
+        "notes": "Pre-drill activation"
+      },
+      {
+        "name": "Banded Heel Push with Hold",
+        "phase": "TAPER",
+        "notes": "Use as low-fade neural primer"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (TKEs)",
+        "phase": "GPP",
+        "notes": "Target VMO"
+      },
+      {
+        "name": "Massage Gun \u2013 Quad Sweep to Patella",
+        "phase": "GPP",
+        "notes": "Reduce tracking tension"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (TKEs)",
+        "phase": "SPP",
+        "notes": "Increase band load or reps"
+      },
+      {
+        "name": "Massage Gun \u2013 Quad Sweep to Patella",
+        "phase": "SPP",
+        "notes": "Use after TKE or compound lifts"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quad & Hip Flexor Stretch",
+        "phase": "GPP",
+        "notes": "Loosen anterior chain"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Line",
+        "phase": "GPP",
+        "notes": "Clear quad tone"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Quad & Hip Flexor Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain extension without CNS load"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Line",
+        "phase": "TAPER",
+        "notes": "Use 30s glides before skill drills"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Sit (Short Arc)",
+        "phase": "GPP",
+        "notes": "Low flexion quad load"
+      },
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "GPP",
+        "notes": "Stabilize tracking"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Sit (Short Arc)",
+        "phase": "SPP",
+        "notes": "Increase depth or add ball squeeze"
+      },
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "SPP",
+        "notes": "Progress to dynamic tempo sets"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lateral Step-Downs",
+        "phase": "GPP",
+        "notes": "Train valgus control"
+      },
+      {
+        "name": "Band-Assisted Lateral Lunges",
+        "phase": "GPP",
+        "notes": "Keep range safe"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Lateral Step-Downs",
+        "phase": "SPP",
+        "notes": "Add range or load with dumbbell"
+      },
+      {
+        "name": "Band-Assisted Lateral Lunges",
+        "phase": "SPP",
+        "notes": "Remove band or increase tempo"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "SPP",
+        "notes": "Reinforce lateral control"
+      },
+      {
+        "name": "Reactive Knee Bounces (Foam Pad)",
+        "phase": "SPP",
+        "notes": "Improve balance under contact"
+      }
+    ]
+  },
+  {
+    "location": "knee",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Mini-Band Lateral Walks",
+        "phase": "TAPER",
+        "notes": "Keep pattern sharp pre-fight"
+      },
+      {
+        "name": "Reactive Knee Bounces (Foam Pad)",
+        "phase": "TAPER",
+        "notes": "Use for CNS reactivity in taper"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hip Flexor Stretch on Wall",
+        "phase": "GPP",
+        "notes": "Open front hip chain"
+      },
+      {
+        "name": "Massage Gun \u2013 TFL to Hip Line",
+        "phase": "GPP",
+        "notes": "Release lateral tightness"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Hip Flexor Stretch on Wall",
+        "phase": "TAPER",
+        "notes": "Maintain range with 30s holds post-spar"
+      },
+      {
+        "name": "Massage Gun \u2013 TFL to Hip Line",
+        "phase": "TAPER",
+        "notes": "Use pre-drill to clear anterior restriction"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Hip Distraction (Lateral)",
+        "phase": "GPP",
+        "notes": "Create space in joint capsule"
+      },
+      {
+        "name": "90/90 Hip Switches",
+        "phase": "GPP",
+        "notes": "Rebuild rotation range"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Hip Distraction (Lateral)",
+        "phase": "SPP",
+        "notes": "Use pre-lift or striking to clear impingement"
+      },
+      {
+        "name": "90/90 Hip Switches",
+        "phase": "SPP",
+        "notes": "Add tempo or band to integrate control"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Monster Walks",
+        "phase": "SPP",
+        "notes": "Strengthen hip stabilizers"
+      },
+      {
+        "name": "Single-Leg Hip Bridge Hold",
+        "phase": "SPP",
+        "notes": "Rebuild unilateral hip control"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Monster Walks",
+        "phase": "TAPER",
+        "notes": "Use low reps for activation pre-session"
+      },
+      {
+        "name": "Single-Leg Hip Bridge Hold",
+        "phase": "TAPER",
+        "notes": "Maintain glute engagement without volume"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Standing Hip CARs",
+        "phase": "GPP",
+        "notes": "Control hip through full pain-free ROM"
+      },
+      {
+        "name": "Massage Gun \u2013 Deep Glute Line",
+        "phase": "GPP",
+        "notes": "Loosen surrounding tissue"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Hip CARs",
+        "phase": "SPP",
+        "notes": "Add tension or hold at end ranges"
+      },
+      {
+        "name": "Massage Gun \u2013 Deep Glute Line",
+        "phase": "SPP",
+        "notes": "Use post-drill to avoid flare-up"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Glute Foam Roll \u2013 Slow Sweep",
+        "phase": "TAPER",
+        "notes": "Reduce DOMS and promote recovery"
+      },
+      {
+        "name": "Mini-Band Standing Hip Abduction",
+        "phase": "TAPER",
+        "notes": "Keep activation without triggering fatigue"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Pigeon Pose Glute Stretch",
+        "phase": "GPP",
+        "notes": "Open up posterior hip"
+      },
+      {
+        "name": "Lacrosse Ball \u2013 Glute Med Sweep",
+        "phase": "GPP",
+        "notes": "Release bound-up tissue"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pigeon Pose Glute Stretch",
+        "phase": "TAPER",
+        "notes": "Hold 20\u201330s post-sparring or kicking"
+      },
+      {
+        "name": "Lacrosse Ball \u2013 Glute Med Sweep",
+        "phase": "TAPER",
+        "notes": "Use short bursts to maintain hip mobility"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Iso Holds",
+        "phase": "GPP",
+        "notes": "Tension without lengthening"
+      },
+      {
+        "name": "Massage Gun \u2013 Glute Max Line",
+        "phase": "GPP",
+        "notes": "Flush tight area"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Iso Holds",
+        "phase": "SPP",
+        "notes": "Add reps or bands for fatigue tolerance"
+      },
+      {
+        "name": "Massage Gun \u2013 Glute Max Line",
+        "phase": "SPP",
+        "notes": "Use post-lift or sprint session"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Clamshells",
+        "phase": "SPP",
+        "notes": "Local glute activation"
+      },
+      {
+        "name": "Foam Roll \u2013 Side Glute Sweep",
+        "phase": "SPP",
+        "notes": "Release lateral glute line"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Clamshells",
+        "phase": "TAPER",
+        "notes": "Short sets pre-training to prevent under-recruitment"
+      },
+      {
+        "name": "Foam Roll \u2013 Side Glute Sweep",
+        "phase": "TAPER",
+        "notes": "Decrease soreness before fight night"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Hip Thrusts",
+        "phase": "GPP",
+        "notes": "Rebuild unilateral power"
+      },
+      {
+        "name": "Mini-Band Glute Kickbacks",
+        "phase": "GPP",
+        "notes": "Focus on contraction"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Hip Thrusts",
+        "phase": "SPP",
+        "notes": "Load with tempo or add pause at top"
+      },
+      {
+        "name": "Mini-Band Glute Kickbacks",
+        "phase": "SPP",
+        "notes": "Progress to continuous sets"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun \u2013 Glute Sweep (30s)",
+        "phase": "TAPER",
+        "notes": "Improve circulation + reduce stiffness on fight week"
+      },
+      {
+        "name": "Isometric Glute Hold in Bridge",
+        "phase": "TAPER",
+        "notes": "Reinforce tension without adding fatigue"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Quad Stretch (Knee to Wall)",
+        "phase": "GPP",
+        "notes": "Improve anterior chain mobility"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Sweep",
+        "phase": "GPP",
+        "notes": "Loosen quad belly"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Quad Stretch (Knee to Wall)",
+        "phase": "TAPER",
+        "notes": "Use daily to maintain stride/kick length"
+      },
+      {
+        "name": "Massage Gun \u2013 Rectus Sweep",
+        "phase": "TAPER",
+        "notes": "Use short bursts pre-drill"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Sit (Mid-Range)",
+        "phase": "GPP",
+        "notes": "Safe tension under no movement"
+      },
+      {
+        "name": "Foam Roller \u2013 Quad Sweep",
+        "phase": "GPP",
+        "notes": "Prep for active rehab"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Sit (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Add reps or instability (ball squeeze)"
+      },
+      {
+        "name": "Foam Roller \u2013 Quad Sweep",
+        "phase": "SPP",
+        "notes": "Post-load flush"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun \u2013 Sweep (VL to VM)",
+        "phase": "TAPER",
+        "notes": "Reset tone without overstimulating CNS"
+      },
+      {
+        "name": "Slow Cycling or AirBike",
+        "phase": "TAPER",
+        "notes": "Light flush to reduce DOMS and stiffness"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mini-Band TKEs (Terminal Knee Extensions)",
+        "phase": "SPP",
+        "notes": "Activate quad without overload"
+      },
+      {
+        "name": "Isometric Quad Flex (Straight Leg)",
+        "phase": "SPP",
+        "notes": "Rebuild control through tension"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Mini-Band TKEs (Terminal Knee Extensions)",
+        "phase": "TAPER",
+        "notes": "Maintain pattern without fatigue"
+      },
+      {
+        "name": "Isometric Quad Flex (Straight Leg)",
+        "phase": "TAPER",
+        "notes": "Use between sets to keep motor pattern sharp"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Quad Percussion \u2013 Massage Gun",
+        "phase": "GPP",
+        "notes": "Desensitize soft tissue"
+      },
+      {
+        "name": "Partial-Range Wall Sit",
+        "phase": "GPP",
+        "notes": "Low-load isometric return"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Light Quad Percussion \u2013 Massage Gun",
+        "phase": "SPP",
+        "notes": "Add sweep post-session"
+      },
+      {
+        "name": "Partial-Range Wall Sit",
+        "phase": "SPP",
+        "notes": "Increase depth gradually"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Hamstring Bridge",
+        "phase": "GPP",
+        "notes": "Mid-range contraction"
+      },
+      {
+        "name": "Massage Gun \u2013 Biceps Femoris Sweep",
+        "phase": "GPP",
+        "notes": "Reduce tension"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Hamstring Bridge",
+        "phase": "SPP",
+        "notes": "Add reps or eccentric control"
+      },
+      {
+        "name": "Massage Gun \u2013 Biceps Femoris Sweep",
+        "phase": "SPP",
+        "notes": "Use after sprint or kick days"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Active Hamstring Kicks (Banded)",
+        "phase": "GPP",
+        "notes": "Mobilize + contract"
+      },
+      {
+        "name": "Lacrosse Ball Under Hamstring",
+        "phase": "GPP",
+        "notes": "Release trigger points"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Active Hamstring Kicks (Banded)",
+        "phase": "TAPER",
+        "notes": "Use during warm-up to maintain speed range"
+      },
+      {
+        "name": "Lacrosse Ball Under Hamstring",
+        "phase": "TAPER",
+        "notes": "Use short passes pre-drill"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Short-Range Nordic Drops (Assisted)",
+        "phase": "SPP",
+        "notes": "Controlled exposure"
+      },
+      {
+        "name": "Foam Roll \u2013 Full Hamstring Sweep",
+        "phase": "SPP",
+        "notes": "Post-load recovery"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Short-Range Nordic Drops (Assisted)",
+        "phase": "TAPER",
+        "notes": "Reduce ROM, keep tension sharp"
+      },
+      {
+        "name": "Foam Roll \u2013 Full Hamstring Sweep",
+        "phase": "TAPER",
+        "notes": "Reset tone pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun \u2013 Hamstring Line",
+        "phase": "TAPER",
+        "notes": "Clear stiffness from sprint/kick load"
+      },
+      {
+        "name": "Reverse AirBike Pedal (Low Intensity)",
+        "phase": "TAPER",
+        "notes": "Restore blood flow without adding fatigue"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Slider Hamstring Curls",
+        "phase": "GPP",
+        "notes": "Controlled curl pattern"
+      },
+      {
+        "name": "Single-Leg Hamstring Bridge",
+        "phase": "GPP",
+        "notes": "Unilateral strength"
+      }
+    ]
+  },
+  {
+    "location": "hamstrings",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Slider Hamstring Curls",
+        "phase": "SPP",
+        "notes": "Increase range or eccentric tempo"
+      },
+      {
+        "name": "Single-Leg Hamstring Bridge",
+        "phase": "SPP",
+        "notes": "Add reps or instability"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side-Lying Hip Adduction",
+        "phase": "GPP",
+        "notes": "Restore baseline groin activation"
+      },
+      {
+        "name": "Standing Cable Adduction",
+        "phase": "GPP",
+        "notes": "Controlled linear tension"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side-Lying Hip Adduction",
+        "phase": "SPP",
+        "notes": "Increase reps under fatigue"
+      },
+      {
+        "name": "Standing Cable Adduction",
+        "phase": "SPP",
+        "notes": "Add tempo or resistance"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Frog Stretch with Breathing",
+        "phase": "GPP",
+        "notes": "Open adductors and hips"
+      },
+      {
+        "name": "Adductor Foam Roll",
+        "phase": "GPP",
+        "notes": "Release dense tissue bands"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Frog Stretch with Breathing",
+        "phase": "TAPER",
+        "notes": "Hold shorter duration to maintain range"
+      },
+      {
+        "name": "Adductor Foam Roll",
+        "phase": "TAPER",
+        "notes": "Pre-spar mobility prep"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Glider Slides (Short Range)",
+        "phase": "TAPER",
+        "notes": "Maintain controlled groin function under no fatigue"
+      },
+      {
+        "name": "Massage Gun Sweep (Adductor Line)",
+        "phase": "TAPER",
+        "notes": "Reduce DOMS across adductor group pre-activation"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Squeeze with Ball",
+        "phase": "GPP",
+        "notes": "Pain-free static activation"
+      },
+      {
+        "name": "Adductor Bridge (Feet on Bench)",
+        "phase": "GPP",
+        "notes": "Build eccentric strength"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Squeeze with Ball",
+        "phase": "SPP",
+        "notes": "Progress to dynamic concentric reps"
+      },
+      {
+        "name": "Adductor Bridge (Feet on Bench)",
+        "phase": "SPP",
+        "notes": "Add tempo or single-leg bias"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Copenhagen Hold (Short Lever)",
+        "phase": "SPP",
+        "notes": "Stabilize hip under load"
+      },
+      {
+        "name": "Single-Leg Balance with Band Pull",
+        "phase": "SPP",
+        "notes": "Challenge reactive adduction"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Copenhagen Hold (Short Lever)",
+        "phase": "TAPER",
+        "notes": "Maintain control under low fatigue"
+      },
+      {
+        "name": "Single-Leg Balance with Band Pull",
+        "phase": "TAPER",
+        "notes": "Sharpen balance without load"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light PNF Groin Stretch",
+        "phase": "GPP",
+        "notes": "Restore contract-relax pattern post-impact"
+      },
+      {
+        "name": "Bodyweight Adductor Lunge",
+        "phase": "GPP",
+        "notes": "Relearn motion path"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Light PNF Groin Stretch",
+        "phase": "SPP",
+        "notes": "Reinforce range"
+      },
+      {
+        "name": "Bodyweight Adductor Lunge",
+        "phase": "SPP",
+        "notes": "Gradually increase depth and control"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Leg Elevation with Diaphragmatic Breathing",
+        "phase": "TAPER",
+        "notes": "Reduce groin fluid pressure"
+      },
+      {
+        "name": "Leg Elevation with Diaphragmatic Breathing",
+        "phase": "TAPER",
+        "notes": "Downregulate nervous system"
+      },
+      {
+        "name": "Wall-Adducted Iso Hold",
+        "phase": "TAPER",
+        "notes": "Hold light activation without strain to maintain tone"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quadruped Rock Back with Adduction Bias",
+        "phase": "GPP",
+        "notes": "Open joint angle pain-free"
+      },
+      {
+        "name": "Standing Hip CARs (Adduction Focus)",
+        "phase": "GPP",
+        "notes": "Restore capsule range"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Quadruped Rock Back with Adduction Bias",
+        "phase": "SPP",
+        "notes": "Advance to active mobility"
+      },
+      {
+        "name": "Standing Hip CARs (Adduction Focus)",
+        "phase": "SPP",
+        "notes": "Control under slight fatigue"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sumo Pulse Squats",
+        "phase": "GPP",
+        "notes": "Mobilize deep groin tissue"
+      },
+      {
+        "name": "Wide Stance RDL with Pause",
+        "phase": "GPP",
+        "notes": "Lengthen adductors"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Sumo Pulse Squats",
+        "phase": "SPP",
+        "notes": "Load pattern gradually"
+      },
+      {
+        "name": "Wide Stance RDL with Pause",
+        "phase": "SPP",
+        "notes": "Add eccentric load to deepen range"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Isometric Adduction Hold",
+        "phase": "GPP",
+        "notes": "Restore tendon tension tolerance"
+      },
+      {
+        "name": "Kettlebell Goblet Cossack Squat",
+        "phase": "GPP",
+        "notes": "Controlled lateral motion"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Isometric Adduction Hold",
+        "phase": "SPP",
+        "notes": "Add duration"
+      },
+      {
+        "name": "Kettlebell Goblet Cossack Squat",
+        "phase": "SPP",
+        "notes": "Build resilience"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Isometric Adduction Hold",
+        "phase": "TAPER",
+        "notes": "Keep active without overload"
+      },
+      {
+        "name": "Kettlebell Goblet Cossack Squat",
+        "phase": "TAPER",
+        "notes": "Reduce depth"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Modified Lateral Lunge with Pause",
+        "phase": "GPP",
+        "notes": "Reinforce hip control at range"
+      },
+      {
+        "name": "Banded Monster Walks (Adduction Bias)",
+        "phase": "GPP",
+        "notes": "Light activation post-overstretch"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Modified Lateral Lunge with Pause",
+        "phase": "SPP",
+        "notes": "Progress tempo and ROM"
+      },
+      {
+        "name": "Banded Monster Walks (Adduction Bias)",
+        "phase": "SPP",
+        "notes": "Rebuild positional control"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall-Supported Copenhagens",
+        "phase": "GPP",
+        "notes": "Low-level groin activation"
+      },
+      {
+        "name": "Standing Hip Adduction with Sliders",
+        "phase": "GPP",
+        "notes": "Controlled range into midline"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall-Supported Copenhagens",
+        "phase": "SPP",
+        "notes": "Shift to unsupported hold"
+      },
+      {
+        "name": "Standing Hip Adduction with Sliders",
+        "phase": "SPP",
+        "notes": "Add tempo or resistance"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Butterfly Stretch",
+        "phase": "GPP",
+        "notes": "Broad adductor release"
+      },
+      {
+        "name": "Isometric Side Lying Squeeze",
+        "phase": "GPP",
+        "notes": "General activation"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Butterfly Stretch",
+        "phase": "TAPER",
+        "notes": "Soft mobility prep before spar"
+      },
+      {
+        "name": "Isometric Side Lying Squeeze",
+        "phase": "TAPER",
+        "notes": "Maintain tone under low CNS stress"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Groin Mobilization (Band Pull)",
+        "phase": "SPP",
+        "notes": "Reestablish active end-range"
+      },
+      {
+        "name": "Pulse Cossack Holds",
+        "phase": "SPP",
+        "notes": "Build capacity through tight angles"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Standing Groin Mobilization (Band Pull)",
+        "phase": "TAPER",
+        "notes": "Maintain feel without load"
+      },
+      {
+        "name": "Pulse Cossack Holds",
+        "phase": "TAPER",
+        "notes": "Lower reps pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Groin Compression with Band + Ice",
+        "phase": "TAPER",
+        "notes": "Reduce DOMS in taper week"
+      },
+      {
+        "name": "Gentle Open Chain Hip Circles",
+        "phase": "TAPER",
+        "notes": "Maintain movement without tension"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ball Squeeze in Supine Bridge",
+        "phase": "GPP",
+        "notes": "Load posterior chain + adductors pain-free"
+      },
+      {
+        "name": "Band-Adducted Lunge Hold",
+        "phase": "GPP",
+        "notes": "Activate under guidance"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Ball Squeeze in Supine Bridge",
+        "phase": "SPP",
+        "notes": "Increase hold or reps"
+      },
+      {
+        "name": "Band-Adducted Lunge Hold",
+        "phase": "SPP",
+        "notes": "Reinforce joint position"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Glute Bridge with Isometric Hold",
+        "phase": "GPP",
+        "notes": "Restore basic hip extension"
+      },
+      {
+        "name": "Quadruped Kickbacks (Band Optional)",
+        "phase": "GPP",
+        "notes": "Reload single-leg pattern"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Glute Bridge with Isometric Hold",
+        "phase": "SPP",
+        "notes": "Add reps or hold under fatigue"
+      },
+      {
+        "name": "Quadruped Kickbacks (Band Optional)",
+        "phase": "SPP",
+        "notes": "Increase range or tension"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Figure-4 Stretch",
+        "phase": "GPP",
+        "notes": "Loosen posterior capsule"
+      },
+      {
+        "name": "Foam Roll \u2013 Glute Med and Max",
+        "phase": "GPP",
+        "notes": "Release high-tension points"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Figure-4 Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain range pre-spar"
+      },
+      {
+        "name": "Foam Roll \u2013 Glute Med and Max",
+        "phase": "TAPER",
+        "notes": "Quick flush for prep"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Band-Abducted March",
+        "phase": "GPP",
+        "notes": "Restore pain-free glute medius drive"
+      },
+      {
+        "name": "Wall Sit with Glute Squeeze",
+        "phase": "GPP",
+        "notes": "Activate without dynamic load"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine Band-Abducted March",
+        "phase": "SPP",
+        "notes": "Add volume under fatigue"
+      },
+      {
+        "name": "Wall Sit with Glute Squeeze",
+        "phase": "SPP",
+        "notes": "Introduce time-under-tension"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "90/90 Hip Rotations",
+        "phase": "GPP",
+        "notes": "Mobilize internal/external rotation"
+      },
+      {
+        "name": "Elevated Pigeon Stretch",
+        "phase": "GPP",
+        "notes": "Deep stretch glute max"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "90/90 Hip Rotations",
+        "phase": "SPP",
+        "notes": "Apply tempo under control"
+      },
+      {
+        "name": "Elevated Pigeon Stretch",
+        "phase": "SPP",
+        "notes": "Progress to band-assisted flow"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Light Banded Side Steps",
+        "phase": "TAPER",
+        "notes": "Gentle reactivation post-DOMS"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Glute Max",
+        "phase": "TAPER",
+        "notes": "Break residual tightness pre-skill work"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hip CARs (Glute Focus)",
+        "phase": "GPP",
+        "notes": "Restore joint clearance and capsule control"
+      },
+      {
+        "name": "Wall-Supported Standing External Rotations",
+        "phase": "GPP",
+        "notes": "Improve glide in end range"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hip CARs (Glute Focus)",
+        "phase": "SPP",
+        "notes": "Apply under minor load"
+      },
+      {
+        "name": "Wall-Supported Standing External Rotations",
+        "phase": "SPP",
+        "notes": "Add band tension to increase challenge"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Glute Bridge (Elevated Foot)",
+        "phase": "SPP",
+        "notes": "Rebuild lateral hip control"
+      },
+      {
+        "name": "Band-Resisted Lateral Lunge",
+        "phase": "SPP",
+        "notes": "Train reactive control"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Single-Leg Glute Bridge (Elevated Foot)",
+        "phase": "TAPER",
+        "notes": "Use slow eccentrics under no load"
+      },
+      {
+        "name": "Band-Resisted Lateral Lunge",
+        "phase": "TAPER",
+        "notes": "Deload but maintain lateral coordination"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Legs with Deep Breathing",
+        "phase": "TAPER",
+        "notes": "Reduce posterior fluid pooling"
+      },
+      {
+        "name": "Elevated Legs with Deep Breathing",
+        "phase": "TAPER",
+        "notes": "Enhance lymphatic flush"
+      },
+      {
+        "name": "Wall-Adducted Iso with Glute Squeeze",
+        "phase": "TAPER",
+        "notes": "Maintain slight tension without CNS load"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Band Resistance",
+        "phase": "GPP",
+        "notes": "Reinforce bracing under low tension"
+      },
+      {
+        "name": "Forearm Plank \u2013 Eccentric Reaches",
+        "phase": "GPP",
+        "notes": "Build tension under control"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Band Resistance",
+        "phase": "SPP",
+        "notes": "Add speed or overhead band angle"
+      },
+      {
+        "name": "Forearm Plank \u2013 Eccentric Reaches",
+        "phase": "SPP",
+        "notes": "Increase time under tension or add movement"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cat-Cow Pelvic Tilts",
+        "phase": "GPP",
+        "notes": "Improve anterior-posterior control"
+      },
+      {
+        "name": "Massage Gun \u2013 Abdominals Sweep",
+        "phase": "GPP",
+        "notes": "Release fascial tightness"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Cat-Cow Pelvic Tilts",
+        "phase": "TAPER",
+        "notes": "Use as warmup to downregulate tone"
+      },
+      {
+        "name": "Massage Gun \u2013 Abdominals Sweep",
+        "phase": "TAPER",
+        "notes": "Use 30s pulse pre-sparring"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Hollow Hold",
+        "phase": "SPP",
+        "notes": "Maximize midline tension"
+      },
+      {
+        "name": "Glute Bridge March (Heel Loaded)",
+        "phase": "SPP",
+        "notes": "Support lumbar offload"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Hollow Hold",
+        "phase": "TAPER",
+        "notes": "Short holds to maintain readiness"
+      },
+      {
+        "name": "Glute Bridge March (Heel Loaded)",
+        "phase": "TAPER",
+        "notes": "Retain cross-chain firing"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug \u2013 Anti-Rotation Focus",
+        "phase": "GPP",
+        "notes": "Reinforce unilateral control"
+      },
+      {
+        "name": "Side Plank with Reach Under",
+        "phase": "GPP",
+        "notes": "Add rotation safely"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug \u2013 Anti-Rotation Focus",
+        "phase": "SPP",
+        "notes": "Progress to cable or band offset load"
+      },
+      {
+        "name": "Side Plank with Reach Under",
+        "phase": "SPP",
+        "notes": "Control twist under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Belly Breathing + 90/90 Reset",
+        "phase": "TAPER",
+        "notes": "Reduce trunk tone"
+      },
+      {
+        "name": "Belly Breathing + 90/90 Reset",
+        "phase": "TAPER",
+        "notes": "Improve diaphragm/core synergy"
+      },
+      {
+        "name": "Massage Gun \u2013 Diagonal Core Sweep",
+        "phase": "TAPER",
+        "notes": "Use short blasts across oblique chain"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Breathing + Arm Reach",
+        "phase": "GPP",
+        "notes": "Maintain deep core activity with minimal pressure"
+      },
+      {
+        "name": "Lacrosse Ball \u2013 Ab Wall Desensitization",
+        "phase": "GPP",
+        "notes": "Light contact to rebuild tolerance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "soreness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Anti-Extension Pressouts",
+        "phase": "SPP",
+        "notes": "Reinforce trunk under fatigue"
+      },
+      {
+        "name": "Bird Dog Reaches",
+        "phase": "SPP",
+        "notes": "Control midline with breath"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Anti-Extension Pressouts",
+        "phase": "TAPER",
+        "notes": "Use short sets to keep tension sharp"
+      },
+      {
+        "name": "Bird Dog Reaches",
+        "phase": "TAPER",
+        "notes": "Integrate pre-drill for trunk priming"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Breathing with Band Pull-Apart",
+        "phase": "GPP",
+        "notes": "Reconnect neuromuscular control with breath"
+      },
+      {
+        "name": "Wall Dead Bug Iso-Hold",
+        "phase": "GPP",
+        "notes": "Maintain tension with joint safety"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank with Band Row",
+        "phase": "GPP",
+        "notes": "Light tension control"
+      },
+      {
+        "name": "Rotational Med Ball Toss (Seated)",
+        "phase": "GPP",
+        "notes": "Start low-impact"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank with Band Row",
+        "phase": "SPP",
+        "notes": "Add rotation and longer holds"
+      },
+      {
+        "name": "Rotational Med Ball Toss (Seated)",
+        "phase": "SPP",
+        "notes": "Progress to standing power variation"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Standing Side Stretch",
+        "phase": "GPP",
+        "notes": "Regain side-chain length"
+      },
+      {
+        "name": "Massage Gun \u2013 External Obliques Sweep",
+        "phase": "GPP",
+        "notes": "Release superficial tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Standing Side Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain mobility pre-fight"
+      },
+      {
+        "name": "Massage Gun \u2013 External Obliques Sweep",
+        "phase": "TAPER",
+        "notes": "Fast glide post-training"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Side Plank \u2013 Short Repeats",
+        "phase": "SPP",
+        "notes": "Maintain engagement under control"
+      },
+      {
+        "name": "Pallof Press (Light Band)",
+        "phase": "SPP",
+        "notes": "Reinforce anti-rotation"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Side Plank \u2013 Short Repeats",
+        "phase": "TAPER",
+        "notes": "Preserve tone with low volume"
+      },
+      {
+        "name": "Pallof Press (Light Band)",
+        "phase": "TAPER",
+        "notes": "Keep transverse activation sharp"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Kneeling Pallof ISO",
+        "phase": "GPP",
+        "notes": "Build control"
+      },
+      {
+        "name": "Side Dead Bug (Offset Load)",
+        "phase": "GPP",
+        "notes": "Train side dominance"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Kneeling Pallof ISO",
+        "phase": "SPP",
+        "notes": "Add split stance or arm drive"
+      },
+      {
+        "name": "Side Dead Bug (Offset Load)",
+        "phase": "SPP",
+        "notes": "Progress toward power drills"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Crocodile Breathing",
+        "phase": "TAPER",
+        "notes": "Reduce lateral wall tone"
+      },
+      {
+        "name": "Ball Rolling on Oblique Chain",
+        "phase": "TAPER",
+        "notes": "Gentle tissue flush to improve comfort"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Bridge with Top Leg Lift",
+        "phase": "SPP",
+        "notes": "Add complexity"
+      },
+      {
+        "name": "Seated Banded Twists",
+        "phase": "SPP",
+        "notes": "Train low-velocity control"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Side Bridge with Top Leg Lift",
+        "phase": "TAPER",
+        "notes": "Reduce hold time, keep activation"
+      },
+      {
+        "name": "Seated Banded Twists",
+        "phase": "TAPER",
+        "notes": "Use quick sets pre-workout"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Child\u2019s Pose with Side Reach",
+        "phase": "GPP",
+        "notes": "Decompress posterior chain"
+      },
+      {
+        "name": "Massage Gun \u2013 Lumbar Sweep",
+        "phase": "GPP",
+        "notes": "Reduce deep fascial tension"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Child\u2019s Pose with Side Reach",
+        "phase": "TAPER",
+        "notes": "Light reset between drills"
+      },
+      {
+        "name": "Massage Gun \u2013 Lumbar Sweep",
+        "phase": "TAPER",
+        "notes": "30s pre-bed or post-sparring"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Walkout",
+        "phase": "GPP",
+        "notes": "Train trunk support via glutes"
+      },
+      {
+        "name": "Quadruped Rock Backs",
+        "phase": "GPP",
+        "notes": "Explore safe range"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Walkout",
+        "phase": "SPP",
+        "notes": "Add tempo for endurance"
+      },
+      {
+        "name": "Quadruped Rock Backs",
+        "phase": "SPP",
+        "notes": "Add band tension or pause"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bird Dog with Band Tension",
+        "phase": "SPP",
+        "notes": "Add reactive core control"
+      },
+      {
+        "name": "Side Plank + Hip Taps",
+        "phase": "SPP",
+        "notes": "Control frontal plane"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Bird Dog with Band Tension",
+        "phase": "TAPER",
+        "notes": "Short reps, tight form"
+      },
+      {
+        "name": "Side Plank + Hip Taps",
+        "phase": "TAPER",
+        "notes": "Maintain side-chain coordination"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine 90/90 Breathing",
+        "phase": "GPP",
+        "notes": "Reduce spinal tone"
+      },
+      {
+        "name": "Wall Dead Bug with Iso Hold",
+        "phase": "GPP",
+        "notes": "Teach bracing"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine 90/90 Breathing",
+        "phase": "SPP",
+        "notes": "Integrate with trunk movement"
+      },
+      {
+        "name": "Wall Dead Bug with Iso Hold",
+        "phase": "SPP",
+        "notes": "Extend hold or add band reach"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Sweep \u2013 Lumbar",
+        "phase": "TAPER",
+        "notes": "Restore blood flow without CNS load"
+      },
+      {
+        "name": "Wall Sit with Neutral Pelvis",
+        "phase": "TAPER",
+        "notes": "Maintain posture while letting soreness downregulate"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Pelvic Tilts",
+        "phase": "GPP",
+        "notes": "Reintroduce control with no load"
+      },
+      {
+        "name": "Bird Dog (Hold Only)",
+        "phase": "GPP",
+        "notes": "Low-stress spinal engagement"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Glute Wall Press (Iso)",
+        "phase": "SPP",
+        "notes": "Rebuild posterior chain"
+      },
+      {
+        "name": "Standing Band Pull-Throughs",
+        "phase": "SPP",
+        "notes": "Load hip hinge"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Glute Wall Press (Iso)",
+        "phase": "TAPER",
+        "notes": "Prime activation"
+      },
+      {
+        "name": "Standing Band Pull-Throughs",
+        "phase": "TAPER",
+        "notes": "Keep low volume"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Support March",
+        "phase": "GPP",
+        "notes": "Control spinal rhythm during step pattern"
+      },
+      {
+        "name": "90/90 Hip Lift + Breathing",
+        "phase": "GPP",
+        "notes": "Reactivate core-trunk link safely"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank with Reach Under",
+        "phase": "GPP",
+        "notes": "Rebuild trunk rotation"
+      },
+      {
+        "name": "Dead Bug with Banded Chop",
+        "phase": "GPP",
+        "notes": "Train oblique tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank with Reach Under",
+        "phase": "SPP",
+        "notes": "Add tempo or load"
+      },
+      {
+        "name": "Dead Bug with Banded Chop",
+        "phase": "SPP",
+        "notes": "Add anti-rotation complexity"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side-Lying Open Book Stretch",
+        "phase": "GPP",
+        "notes": "Restore side-line rotation"
+      },
+      {
+        "name": "Massage Gun Sweep (Oblique Ridge)",
+        "phase": "GPP",
+        "notes": "Break up fascial tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Side-Lying Open Book Stretch",
+        "phase": "TAPER",
+        "notes": "Use as cooldown reset"
+      },
+      {
+        "name": "Massage Gun Sweep (Oblique Ridge)",
+        "phase": "TAPER",
+        "notes": "Quick flush pre-spar"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Standing Side Bends (Bodyweight)",
+        "phase": "TAPER",
+        "notes": "Mobilize trunk gently without added strain"
+      },
+      {
+        "name": "Wall Slide Iso (Side Hold)",
+        "phase": "TAPER",
+        "notes": "Light activation for postural balance"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Lateral Flexion Holds",
+        "phase": "GPP",
+        "notes": "Restore lateral range"
+      },
+      {
+        "name": "Banded Lateral Step + Trunk Rotation",
+        "phase": "GPP",
+        "notes": "Reintegrate motion pattern"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Lateral Flexion Holds",
+        "phase": "SPP",
+        "notes": "Increase hold duration under band load"
+      },
+      {
+        "name": "Banded Lateral Step + Trunk Rotation",
+        "phase": "SPP",
+        "notes": "Load diagonal plane safely"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Cable Chop",
+        "phase": "SPP",
+        "notes": "Controlled explosive rotation"
+      },
+      {
+        "name": "Rotational Med Ball Toss (Wall)",
+        "phase": "SPP",
+        "notes": "Dynamic force output"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Half-Kneeling Cable Chop",
+        "phase": "TAPER",
+        "notes": "Lighter resistance for speed"
+      },
+      {
+        "name": "Rotational Med Ball Toss (Wall)",
+        "phase": "TAPER",
+        "notes": "Focus on sharpness, low fatigue"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roll \u2013 Oblique Line",
+        "phase": "GPP",
+        "notes": "Target fascial knots"
+      },
+      {
+        "name": "Side Plank March",
+        "phase": "GPP",
+        "notes": "Reset pelvic control"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Foam Roll \u2013 Oblique Line",
+        "phase": "SPP",
+        "notes": "Maintain mobility with control"
+      },
+      {
+        "name": "Side Plank March",
+        "phase": "SPP",
+        "notes": "Advance to dynamic marching"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Side Plank on Elbow",
+        "phase": "GPP",
+        "notes": "Safe reintroduction to load"
+      },
+      {
+        "name": "Wall Cable Isometric Hold (Lateral)",
+        "phase": "GPP",
+        "notes": "Minimal-movement tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Side Plank on Elbow",
+        "phase": "SPP",
+        "notes": "Progress with reach or band"
+      },
+      {
+        "name": "Wall Cable Isometric Hold (Lateral)",
+        "phase": "SPP",
+        "notes": "Add diagonal force"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Trunk CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Reestablish capsule mobility"
+      },
+      {
+        "name": "Seated Banded Rotation",
+        "phase": "GPP",
+        "notes": "Reintroduce end-range tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Trunk CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Control under tension"
+      },
+      {
+        "name": "Seated Banded Rotation",
+        "phase": "SPP",
+        "notes": "Add banded velocity"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Kneeling Cable Hold + Rotate",
+        "phase": "GPP",
+        "notes": "Control movement in neutral range"
+      },
+      {
+        "name": "Side-Lying Leg Lifts (Anti-Rotation Focus)",
+        "phase": "GPP",
+        "notes": "Rebuild baseline control"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Kneeling Cable Hold + Rotate",
+        "phase": "SPP",
+        "notes": "Add rotation under load"
+      },
+      {
+        "name": "Side-Lying Leg Lifts (Anti-Rotation Focus)",
+        "phase": "SPP",
+        "notes": "Layer in tempo"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Handheld Vibration Over Lateral Core",
+        "phase": "GPP",
+        "notes": "Ease bruised site"
+      },
+      {
+        "name": "Quadruped Reach-Through Stretch",
+        "phase": "GPP",
+        "notes": "Mobilize gently through pain-free range"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Handheld Vibration Over Lateral Core",
+        "phase": "TAPER",
+        "notes": "Use light percussion pre-fight"
+      },
+      {
+        "name": "Quadruped Reach-Through Stretch",
+        "phase": "TAPER",
+        "notes": "Restore movement fluency"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "90/90 Breathing with Lateral Expansion",
+        "phase": "TAPER",
+        "notes": "Encourage oblique drainage and reset breathing"
+      },
+      {
+        "name": "Copenhagen Iso (Short Lever)",
+        "phase": "TAPER",
+        "notes": "Light trunk bracing without full trunk strain"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank Eccentrics",
+        "phase": "GPP",
+        "notes": "Control descent and regain tissue load"
+      },
+      {
+        "name": "Cable Chop + Return",
+        "phase": "GPP",
+        "notes": "Reinforce contractile tension"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank Eccentrics",
+        "phase": "SPP",
+        "notes": "Add banded rotation"
+      },
+      {
+        "name": "Cable Chop + Return",
+        "phase": "SPP",
+        "notes": "Build output under load"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Side Plank Eccentrics",
+        "phase": "TAPER",
+        "notes": "Maintain tone, low fatigue"
+      },
+      {
+        "name": "Cable Chop + Return",
+        "phase": "TAPER",
+        "notes": "Back off for speed"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Band Hold + Walkout",
+        "phase": "SPP",
+        "notes": "Reinforce anti-rotation under displacement"
+      },
+      {
+        "name": "Split Stance Press with Rotation",
+        "phase": "SPP",
+        "notes": "Add dynamic rotation under control"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Standing Band Hold + Walkout",
+        "phase": "TAPER",
+        "notes": "Reduce range, keep tension"
+      },
+      {
+        "name": "Split Stance Press with Rotation",
+        "phase": "TAPER",
+        "notes": "Reduce load, sharpen movement"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Lat + Oblique Opener",
+        "phase": "SPP",
+        "notes": "Restore range in side lines"
+      },
+      {
+        "name": "Seated Banded Overhead Reach",
+        "phase": "SPP",
+        "notes": "Isolate lateral lines safely"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Lat + Oblique Opener",
+        "phase": "TAPER",
+        "notes": "Use as pre-session opener"
+      },
+      {
+        "name": "Seated Banded Overhead Reach",
+        "phase": "TAPER",
+        "notes": "Maintain length under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank with Banded Reach",
+        "phase": "GPP",
+        "notes": "Control trunk range"
+      },
+      {
+        "name": "Med Ball Side Wall Toss (Short Range)",
+        "phase": "GPP",
+        "notes": "Reinforce safe return"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank with Banded Reach",
+        "phase": "SPP",
+        "notes": "Add diagonal tension under load"
+      },
+      {
+        "name": "Med Ball Side Wall Toss (Short Range)",
+        "phase": "SPP",
+        "notes": "Rebuild explosive output"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Band Press (Diagonal)",
+        "phase": "GPP",
+        "notes": "Cover all ranges with low load"
+      },
+      {
+        "name": "Rotational Pulse Lifts",
+        "phase": "GPP",
+        "notes": "Global control"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Half-Kneeling Band Press (Diagonal)",
+        "phase": "TAPER",
+        "notes": "Lock in posture under light tension"
+      },
+      {
+        "name": "Rotational Pulse Lifts",
+        "phase": "TAPER",
+        "notes": "Maintain readiness without volume"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Child\u2019s Pose with Side Reach",
+        "phase": "GPP",
+        "notes": "Decompress posterior chain"
+      },
+      {
+        "name": "Massage Gun \u2013 Lumbar Sweep",
+        "phase": "GPP",
+        "notes": "Flush fascial tightness"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Child\u2019s Pose with Side Reach",
+        "phase": "TAPER",
+        "notes": "Reset tension during taper week"
+      },
+      {
+        "name": "Massage Gun \u2013 Lumbar Sweep",
+        "phase": "TAPER",
+        "notes": "Light pulse post-session"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Walkouts",
+        "phase": "GPP",
+        "notes": "Restore posterior chain rhythm"
+      },
+      {
+        "name": "Bird Dog with Reach",
+        "phase": "GPP",
+        "notes": "Train trunk-limb sync"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Glute Bridge Walkouts",
+        "phase": "SPP",
+        "notes": "Add tempo or resistance band"
+      },
+      {
+        "name": "Bird Dog with Reach",
+        "phase": "SPP",
+        "notes": "Introduce slow reps or banded drag"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Quadruped Hover Holds",
+        "phase": "SPP",
+        "notes": "Build midline integrity"
+      },
+      {
+        "name": "Side Plank with Posterior Reach",
+        "phase": "SPP",
+        "notes": "Anchor oblique/back interface"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Quadruped Hover Holds",
+        "phase": "TAPER",
+        "notes": "Short holds for CNS freshness"
+      },
+      {
+        "name": "Side Plank with Posterior Reach",
+        "phase": "TAPER",
+        "notes": "Maintain under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine 90/90 Breathing",
+        "phase": "GPP",
+        "notes": "Downregulate spinal tone"
+      },
+      {
+        "name": "Wall Dead Bug Iso Hold",
+        "phase": "GPP",
+        "notes": "Lock lumbar control"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine 90/90 Breathing",
+        "phase": "SPP",
+        "notes": "Tie into movement bracing"
+      },
+      {
+        "name": "Wall Dead Bug Iso Hold",
+        "phase": "SPP",
+        "notes": "Add reach or band tension"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lying Knee to Chest Hold",
+        "phase": "TAPER",
+        "notes": "Flush lower back tension gently"
+      },
+      {
+        "name": "Foam Roll \u2013 Low Spine Sweep",
+        "phase": "TAPER",
+        "notes": "Reset post-training stiffness"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cat-Cow with Deep Breathing",
+        "phase": "GPP",
+        "notes": "Restore spinal rhythm"
+      },
+      {
+        "name": "Jefferson Curl (Light DB)",
+        "phase": "GPP",
+        "notes": "Train loaded articulation"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cat-Cow with Deep Breathing",
+        "phase": "SPP",
+        "notes": "Improve active control"
+      },
+      {
+        "name": "Jefferson Curl (Light DB)",
+        "phase": "SPP",
+        "notes": "Extend ROM with tempo"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Reverse Hyperextensions (Banded)",
+        "phase": "GPP",
+        "notes": "Increase glute/hamstring firing"
+      },
+      {
+        "name": "Banded Hip Hinge Reps",
+        "phase": "GPP",
+        "notes": "Pattern hinge without stress"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reverse Hyperextensions (Banded)",
+        "phase": "SPP",
+        "notes": "Add load for trunk reactivity"
+      },
+      {
+        "name": "Banded Hip Hinge Reps",
+        "phase": "SPP",
+        "notes": "Load into resistance"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Percussion Gun \u2013 Lumbar Focus",
+        "phase": "GPP",
+        "notes": "Desensitize bruised area"
+      },
+      {
+        "name": "Bridge Iso Hold on Pad",
+        "phase": "GPP",
+        "notes": "Rebuild safe base tension"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Percussion Gun \u2013 Lumbar Focus",
+        "phase": "TAPER",
+        "notes": "Light flush"
+      },
+      {
+        "name": "Bridge Iso Hold on Pad",
+        "phase": "TAPER",
+        "notes": "Maintain control without movement"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Pelvic Tilts (Supine)",
+        "phase": "GPP",
+        "notes": "Rebuild lumbar control"
+      },
+      {
+        "name": "Bird Dog Iso Hold",
+        "phase": "GPP",
+        "notes": "Stabilize posterior chain"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pelvic Tilts (Supine)",
+        "phase": "SPP",
+        "notes": "Advance to standing hinge patterns"
+      },
+      {
+        "name": "Bird Dog Iso Hold",
+        "phase": "SPP",
+        "notes": "Add tempo and reach"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roll Sweep (Erector Zone)",
+        "phase": "GPP",
+        "notes": "Reset surface tension"
+      },
+      {
+        "name": "Glute Bridge with Arm Reach",
+        "phase": "GPP",
+        "notes": "Offload pressure"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roll Sweep (Erector Zone)",
+        "phase": "TAPER",
+        "notes": "Gentle flush only"
+      },
+      {
+        "name": "Glute Bridge with Arm Reach",
+        "phase": "TAPER",
+        "notes": "Maintain posterior chain activation"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "90/90 Breathing with Feet Elevated",
+        "phase": "TAPER",
+        "notes": "Drain pressure via parasympathetic tilt"
+      },
+      {
+        "name": "Cat-Cow Flow (Slow Tempo)",
+        "phase": "TAPER",
+        "notes": "Restore motion with low CNS load"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Good Morning (Banded)",
+        "phase": "GPP",
+        "notes": "Reinforce controlled hinge"
+      },
+      {
+        "name": "Reverse Hypers (Bodyweight or Band)",
+        "phase": "GPP",
+        "notes": "Restore spinal extension"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Good Morning (Banded)",
+        "phase": "SPP",
+        "notes": "Add load or tempo"
+      },
+      {
+        "name": "Reverse Hypers (Bodyweight or Band)",
+        "phase": "SPP",
+        "notes": "Add light weight"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Good Morning (Banded)",
+        "phase": "TAPER",
+        "notes": "Maintain range"
+      },
+      {
+        "name": "Reverse Hypers (Bodyweight or Band)",
+        "phase": "TAPER",
+        "notes": "Keep activation only"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug Hold with Heel Tap",
+        "phase": "GPP",
+        "notes": "Reconnect core-to-spine control"
+      },
+      {
+        "name": "Quadruped Rock Back with Reach",
+        "phase": "GPP",
+        "notes": "Mobilize hips without lumbar load"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug Hold with Heel Tap",
+        "phase": "SPP",
+        "notes": "Add band for anti-extension stress"
+      },
+      {
+        "name": "Quadruped Rock Back with Reach",
+        "phase": "SPP",
+        "notes": "Integrate deep core brace"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank March",
+        "phase": "SPP",
+        "notes": "Reinforce lateral stability"
+      },
+      {
+        "name": "Stir the Pot (Swiss Ball)",
+        "phase": "SPP",
+        "notes": "Load global core"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Side Plank March",
+        "phase": "TAPER",
+        "notes": "Maintain engagement without fatigue"
+      },
+      {
+        "name": "Stir the Pot (Swiss Ball)",
+        "phase": "TAPER",
+        "notes": "Reduce volume, maintain control"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Hip Hinge Hold",
+        "phase": "GPP",
+        "notes": "Prevent overextension under load"
+      },
+      {
+        "name": "Wall Deadlift Patterning (Back Flat)",
+        "phase": "GPP",
+        "notes": "Teach safe hinge form"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Hip Hinge Hold",
+        "phase": "SPP",
+        "notes": "Add banded glute drive"
+      },
+      {
+        "name": "Wall Deadlift Patterning (Back Flat)",
+        "phase": "SPP",
+        "notes": "Add resistance or tempo"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine March with Band",
+        "phase": "GPP",
+        "notes": "Safe posterior chain control"
+      },
+      {
+        "name": "Standing Anti-Rotation Press",
+        "phase": "GPP",
+        "notes": "Train brace under load"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Supine March with Band",
+        "phase": "TAPER",
+        "notes": "Light tension only"
+      },
+      {
+        "name": "Standing Anti-Rotation Press",
+        "phase": "TAPER",
+        "notes": "Reduce fatigue, keep pattern sharp"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roll Thoracic Extension",
+        "phase": "GPP",
+        "notes": "Restore upper spine mobility"
+      },
+      {
+        "name": "Wall Slides with Chin Tuck",
+        "phase": "GPP",
+        "notes": "Improve scapular rhythm"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roll Thoracic Extension",
+        "phase": "TAPER",
+        "notes": "Maintain posture prep"
+      },
+      {
+        "name": "Wall Slides with Chin Tuck",
+        "phase": "TAPER",
+        "notes": "Use pre-warmup"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Prone Swimmers",
+        "phase": "GPP",
+        "notes": "Activate scapular rotation"
+      },
+      {
+        "name": "Scapular Push-Ups",
+        "phase": "GPP",
+        "notes": "Restore control"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Prone Swimmers",
+        "phase": "SPP",
+        "notes": "Add tempo or resistance"
+      },
+      {
+        "name": "Scapular Push-Ups",
+        "phase": "SPP",
+        "notes": "Integrate tempo or unstable surface"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Angels",
+        "phase": "SPP",
+        "notes": "Improve scapular glide"
+      },
+      {
+        "name": "Massage Gun \u2013 T-Spine Sweep",
+        "phase": "SPP",
+        "notes": "Reduce local tone"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Angels",
+        "phase": "TAPER",
+        "notes": "Retain postural awareness"
+      },
+      {
+        "name": "Massage Gun \u2013 T-Spine Sweep",
+        "phase": "TAPER",
+        "notes": "Flush tension post-spar"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Band Pull-Aparts (High Rep)",
+        "phase": "TAPER",
+        "notes": "Maintain blood flow and rhythm"
+      },
+      {
+        "name": "Foam Roll \u2013 T-Spine Sweep",
+        "phase": "TAPER",
+        "notes": "Reset tightness before drills"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Band Overhead",
+        "phase": "GPP",
+        "notes": "Open shoulder blade pathway"
+      },
+      {
+        "name": "Thoracic Rotation on All Fours",
+        "phase": "GPP",
+        "notes": "Unlock thoracic joints"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Band Overhead",
+        "phase": "SPP",
+        "notes": "Integrate vertical motion with control"
+      },
+      {
+        "name": "Thoracic Rotation on All Fours",
+        "phase": "SPP",
+        "notes": "Add resistance band for challenge"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Active Thread the Needle",
+        "phase": "SPP",
+        "notes": "Mobilize spine actively"
+      },
+      {
+        "name": "Band-Assisted Overhead Reach",
+        "phase": "SPP",
+        "notes": "Lengthen lat and upper back tissue"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Active Thread the Needle",
+        "phase": "TAPER",
+        "notes": "Maintain with low CNS drain"
+      },
+      {
+        "name": "Band-Assisted Overhead Reach",
+        "phase": "TAPER",
+        "notes": "Short reps only"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall-Leaning Thoracic Opener",
+        "phase": "GPP",
+        "notes": "Isolate T-spine articulation"
+      },
+      {
+        "name": "Quadruped Rockbacks with Rotation",
+        "phase": "GPP",
+        "notes": "Restore lateral rotation"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall-Leaning Thoracic Opener",
+        "phase": "SPP",
+        "notes": "Add controlled deep breath holds"
+      },
+      {
+        "name": "Quadruped Rockbacks with Rotation",
+        "phase": "SPP",
+        "notes": "Add pause or band tension"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Scapular Wall Hold with Band",
+        "phase": "GPP",
+        "notes": "Re-engage scapular base"
+      },
+      {
+        "name": "Y-T-W Isometric Holds",
+        "phase": "GPP",
+        "notes": "Lock shoulder blade in multiple angles"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Scapular Wall Hold with Band",
+        "phase": "SPP",
+        "notes": "Add pull tension and reach"
+      },
+      {
+        "name": "Y-T-W Isometric Holds",
+        "phase": "SPP",
+        "notes": "Load with tempo reps"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Suspended Row (TRX or Rings)",
+        "phase": "SPP",
+        "notes": "Train controlled pulling under fatigue"
+      },
+      {
+        "name": "Resistance Band Reverse Flys",
+        "phase": "SPP",
+        "notes": "Focus scapular control"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Suspended Row (TRX or Rings)",
+        "phase": "TAPER",
+        "notes": "Reduce angle for flush volume"
+      },
+      {
+        "name": "Resistance Band Reverse Flys",
+        "phase": "TAPER",
+        "notes": "Light pump sets"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall-Supported Face Pulls",
+        "phase": "GPP",
+        "notes": "Reinforce scapular retraction"
+      },
+      {
+        "name": "One-Arm Band Row with Rotation",
+        "phase": "GPP",
+        "notes": "Restore cross-body tension"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall-Supported Face Pulls",
+        "phase": "SPP",
+        "notes": "Add slow eccentric or unstable stance"
+      },
+      {
+        "name": "One-Arm Band Row with Rotation",
+        "phase": "SPP",
+        "notes": "Load rotation into pulling"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Pull-Aparts",
+        "phase": "GPP",
+        "notes": "Start with slow eccentric"
+      },
+      {
+        "name": "Scap Push-Ups with Pause",
+        "phase": "GPP",
+        "notes": "Build control in press path"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Pull-Aparts",
+        "phase": "SPP",
+        "notes": "Increase reps and resistance"
+      },
+      {
+        "name": "Scap Push-Ups with Pause",
+        "phase": "SPP",
+        "notes": "Add reps or band tension"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Band Pull-Aparts",
+        "phase": "TAPER",
+        "notes": "Maintain frequency, reduce volume"
+      },
+      {
+        "name": "Scap Push-Ups with Pause",
+        "phase": "TAPER",
+        "notes": "Maintain activation"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lacrosse Ball Wall Roll (T-Spine)",
+        "phase": "GPP",
+        "notes": "Tolerate local pressure"
+      },
+      {
+        "name": "Band Assisted Lateral Reach",
+        "phase": "GPP",
+        "notes": "Restore end-range reach"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lacrosse Ball Wall Roll (T-Spine)",
+        "phase": "TAPER",
+        "notes": "Reset small knots before training"
+      },
+      {
+        "name": "Band Assisted Lateral Reach",
+        "phase": "TAPER",
+        "notes": "Light mobility for freedom"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Incline Bench Retraction Holds",
+        "phase": "GPP",
+        "notes": "Reinforce end-range safety"
+      },
+      {
+        "name": "Wall Reverse Shrugs",
+        "phase": "GPP",
+        "notes": "Low-risk scap activation"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Incline Bench Retraction Holds",
+        "phase": "SPP",
+        "notes": "Build control under slow reps"
+      },
+      {
+        "name": "Wall Reverse Shrugs",
+        "phase": "SPP",
+        "notes": "Add load or isometric squeeze"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Arm Elevation Wall Slides",
+        "phase": "TAPER",
+        "notes": "Promote lymphatic flow post-spar"
+      },
+      {
+        "name": "Foam Rolling \u2013 Vertical Sweep",
+        "phase": "TAPER",
+        "notes": "Reset inflammation without pressure"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band Lat Stretch (Underhand Grip)",
+        "phase": "GPP",
+        "notes": "Offload posterior tension"
+      },
+      {
+        "name": "Kneeling Band Row to External Rotation",
+        "phase": "GPP",
+        "notes": "Introduce scapular control"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band Lat Stretch (Underhand Grip)",
+        "phase": "SPP",
+        "notes": "Blend into active range"
+      },
+      {
+        "name": "Kneeling Band Row to External Rotation",
+        "phase": "SPP",
+        "notes": "Build external rotator strength"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slide + Posterior Tilt",
+        "phase": "GPP",
+        "notes": "Restore scapular slide pattern"
+      },
+      {
+        "name": "Overhead Band Pull-Throughs",
+        "phase": "GPP",
+        "notes": "Engage full back chain safely"
+      }
+    ]
+  },
+  {
+    "location": "upper back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Slide + Posterior Tilt",
+        "phase": "TAPER",
+        "notes": "Maintain CNS awareness with short holds"
+      },
+      {
+        "name": "Overhead Band Pull-Throughs",
+        "phase": "TAPER",
+        "notes": "Low resistance pre-activation"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Push (Chest Height)",
+        "phase": "GPP",
+        "notes": "Safely reactivate pectorals"
+      },
+      {
+        "name": "Resistance Band Chest Fly",
+        "phase": "GPP",
+        "notes": "Control range of motion"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Push (Chest Height)",
+        "phase": "SPP",
+        "notes": "Increase force duration under tension"
+      },
+      {
+        "name": "Resistance Band Chest Fly",
+        "phase": "SPP",
+        "notes": "Add eccentric tempo"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Pec Stretch (Open Arm)",
+        "phase": "GPP",
+        "notes": "Reset anterior chain posture"
+      },
+      {
+        "name": "Wall Slide with Overhead Reach",
+        "phase": "GPP",
+        "notes": "Restore scapulo-humeral rhythm"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Pec Stretch (Open Arm)",
+        "phase": "TAPER",
+        "notes": "Maintain soft tissue length"
+      },
+      {
+        "name": "Wall Slide with Overhead Reach",
+        "phase": "TAPER",
+        "notes": "Keep thoracic glide active"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Massage Gun Sweep (Pec Major)",
+        "phase": "GPP",
+        "notes": "Reduce tissue density and bruising"
+      },
+      {
+        "name": "Scapular Wall Lift-Offs",
+        "phase": "GPP",
+        "notes": "Activate surrounding stabilizers"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun Sweep (Pec Major)",
+        "phase": "TAPER",
+        "notes": "Gentle flush before training"
+      },
+      {
+        "name": "Scapular Wall Lift-Offs",
+        "phase": "TAPER",
+        "notes": "Isolate under light load"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Press (Single Arm)",
+        "phase": "GPP",
+        "notes": "Restore tendon control"
+      },
+      {
+        "name": "Crossover Pec Stretch",
+        "phase": "GPP",
+        "notes": "Mobilize surrounding tissue"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Press (Single Arm)",
+        "phase": "SPP",
+        "notes": "Add controlled reps"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Band Press (Single Arm)",
+        "phase": "TAPER",
+        "notes": "Maintain tone without fatigue"
+      },
+      {
+        "name": "Crossover Pec Stretch",
+        "phase": "TAPER",
+        "notes": "Reduce tightness pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Suspended Isometric Push-Up Hold",
+        "phase": "GPP",
+        "notes": "Tension without range"
+      },
+      {
+        "name": "Chest Press with Band (Neutral Grip)",
+        "phase": "GPP",
+        "notes": "Minimize joint stress"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Suspended Isometric Push-Up Hold",
+        "phase": "SPP",
+        "notes": "Add tempo descent"
+      },
+      {
+        "name": "Chest Press with Band (Neutral Grip)",
+        "phase": "SPP",
+        "notes": "Layer in explosive intent"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Open Chain Arm Circles",
+        "phase": "TAPER",
+        "notes": "Promote blood flow without resistance"
+      },
+      {
+        "name": "Wall Slide Pec Activation",
+        "phase": "TAPER",
+        "notes": "Gentle prep before upper-body sessions"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Pec Stretch (Elbow High)",
+        "phase": "TAPER",
+        "notes": "Decompress upper pecs post-session"
+      },
+      {
+        "name": "Arm Cross Pull with Deep Breathing",
+        "phase": "TAPER",
+        "notes": "Reset tension and breathing patterns"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Chest-Supported Banded Row",
+        "phase": "GPP",
+        "notes": "Train posterior chain safely"
+      },
+      {
+        "name": "Isometric Chest Squeeze (Swiss Ball)",
+        "phase": "GPP",
+        "notes": "Activate without movement"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chest-Supported Banded Row",
+        "phase": "SPP",
+        "notes": "Rebalance push-pull system"
+      },
+      {
+        "name": "Isometric Chest Squeeze (Swiss Ball)",
+        "phase": "SPP",
+        "notes": "Add tempo hold"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pec Minor Doorway Stretch",
+        "phase": "SPP",
+        "notes": "Mobilize under control"
+      },
+      {
+        "name": "Band Pull-Apart with Pause",
+        "phase": "SPP",
+        "notes": "Reinforce scapular glide"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pec Minor Doorway Stretch",
+        "phase": "TAPER",
+        "notes": "Sustain mobility for upper-body rhythm"
+      },
+      {
+        "name": "Band Pull-Apart with Pause",
+        "phase": "TAPER",
+        "notes": "Reduce tightness without overworking"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Scapular Retraction Wall Slide",
+        "phase": "GPP",
+        "notes": "Restore shoulder-blade mechanics"
+      },
+      {
+        "name": "Single-Arm Cable Press from Split Stance",
+        "phase": "GPP",
+        "notes": "Build control in safe range"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Scapular Retraction Wall Slide",
+        "phase": "SPP",
+        "notes": "Add band tension under control"
+      },
+      {
+        "name": "Single-Arm Cable Press from Split Stance",
+        "phase": "SPP",
+        "notes": "Reinforce force path through chest"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chaos Push-Up (Band Suspension)",
+        "phase": "SPP",
+        "notes": "Rebuild reactive control"
+      },
+      {
+        "name": "Standing Band Press with Lateral Pull",
+        "phase": "SPP",
+        "notes": "Add asymmetry to load path"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Chaos Push-Up (Band Suspension)",
+        "phase": "TAPER",
+        "notes": "Keep stimulus light but sharp"
+      },
+      {
+        "name": "Standing Band Press with Lateral Pull",
+        "phase": "TAPER",
+        "notes": "Regulate tension before fight"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Incline Press Isometric Hold",
+        "phase": "GPP",
+        "notes": "Lock in safe shoulder angles"
+      },
+      {
+        "name": "Scapular Wall Drill with Chest Focus",
+        "phase": "GPP",
+        "notes": "Control thoracic extension"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Incline Press Isometric Hold",
+        "phase": "SPP",
+        "notes": "Build tension without overextension"
+      },
+      {
+        "name": "Scapular Wall Drill with Chest Focus",
+        "phase": "SPP",
+        "notes": "Prevent further overload"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Band Press from Floor",
+        "phase": "GPP",
+        "notes": "Full-range control"
+      },
+      {
+        "name": "Pec-Focused Plyo Push-Off (Low Intensity)",
+        "phase": "GPP",
+        "notes": "Dynamic return to load"
+      }
+    ]
+  },
+  {
+    "location": "chest",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Light Band Press from Floor",
+        "phase": "TAPER",
+        "notes": "Sharp prep work pre-activation"
+      },
+      {
+        "name": "Pec-Focused Plyo Push-Off (Low Intensity)",
+        "phase": "TAPER",
+        "notes": "Maintain reactivity"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Foam Roller",
+        "phase": "GPP",
+        "notes": "Rebuild scapular rhythm (anterior deltoid)"
+      },
+      {
+        "name": "Landmine Shoulder Press",
+        "phase": "GPP",
+        "notes": "Safe press angle for anterior strain"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Foam Roller",
+        "phase": "SPP",
+        "notes": "Increase range with light resistance"
+      },
+      {
+        "name": "Landmine Shoulder Press",
+        "phase": "SPP",
+        "notes": "Add tempo or pause at top"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sleeper Stretch",
+        "phase": "GPP",
+        "notes": "Release posterior capsule"
+      },
+      {
+        "name": "Cross-Body Band Stretch",
+        "phase": "GPP",
+        "notes": "Improve tissue glide"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Sleeper Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain horizontal rotation range"
+      },
+      {
+        "name": "Cross-Body Band Stretch",
+        "phase": "TAPER",
+        "notes": "Quick pre-session opener"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Push (Shoulder Level)",
+        "phase": "SPP",
+        "notes": "Activate without motion (anterior)"
+      },
+      {
+        "name": "Banded Face Pull Iso Hold",
+        "phase": "SPP",
+        "notes": "Posterior activation without elevation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Wall Push (Shoulder Level)",
+        "phase": "TAPER",
+        "notes": "Sustain low-level tension"
+      },
+      {
+        "name": "Banded Face Pull Iso Hold",
+        "phase": "TAPER",
+        "notes": "Retain postural control"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "PVC Shoulder Pass-Throughs",
+        "phase": "GPP",
+        "notes": "Mobilize anterior and lateral lines"
+      },
+      {
+        "name": "Banded Internal Rotations",
+        "phase": "GPP",
+        "notes": "Free up subscap/tendon"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "PVC Shoulder Pass-Throughs",
+        "phase": "SPP",
+        "notes": "Increase speed and range"
+      },
+      {
+        "name": "Banded Internal Rotations",
+        "phase": "SPP",
+        "notes": "Add tempo resistance"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Scapular Wall Slides with Chin Tuck",
+        "phase": "GPP",
+        "notes": "Reset scapular position"
+      },
+      {
+        "name": "Prone W to Y Lifts",
+        "phase": "GPP",
+        "notes": "Recruit mid/lower trap"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Scapular Wall Slides with Chin Tuck",
+        "phase": "SPP",
+        "notes": "Maintain position under slow tempo"
+      },
+      {
+        "name": "Prone W to Y Lifts",
+        "phase": "SPP",
+        "notes": "Integrate posterior chain"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "impingement",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Scapular Wall Slides with Chin Tuck",
+        "phase": "TAPER",
+        "notes": "Precision control"
+      },
+      {
+        "name": "Prone W to Y Lifts",
+        "phase": "TAPER",
+        "notes": "Stabilize without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun (Posterior Head)",
+        "phase": "TAPER",
+        "notes": "Reduce tension in posterior deltoid after heavy pull days"
+      },
+      {
+        "name": "Wall Clock Circles (Bodyweight)",
+        "phase": "TAPER",
+        "notes": "Active mobility without strain"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Gentle Band Pull-Aparts",
+        "phase": "GPP",
+        "notes": "Light posterior chain reactivation"
+      },
+      {
+        "name": "Passive Arm Hang (Trap Bar Support)",
+        "phase": "GPP",
+        "notes": "Restore overhead comfort"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "contusion",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Gentle Band Pull-Aparts",
+        "phase": "TAPER",
+        "notes": "Maintain tolerance post-contact"
+      },
+      {
+        "name": "Passive Arm Hang (Trap Bar Support)",
+        "phase": "TAPER",
+        "notes": "Offload without CNS drain"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "KB Bottom-Up Carry",
+        "phase": "SPP",
+        "notes": "Dynamic control through all planes (anterior + lateral head)"
+      },
+      {
+        "name": "Wall Walks (Isometric)",
+        "phase": "SPP",
+        "notes": "Reinforce rotator cuff"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "KB Bottom-Up Carry",
+        "phase": "TAPER",
+        "notes": "Short distance holds"
+      },
+      {
+        "name": "Wall Walks (Isometric)",
+        "phase": "TAPER",
+        "notes": "Static control with feedback"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Banded Row",
+        "phase": "GPP",
+        "notes": "Reintroduce posterior drive"
+      },
+      {
+        "name": "Wall-Supported External Rotation",
+        "phase": "GPP",
+        "notes": "Low-friction cuff loading"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Banded Row",
+        "phase": "SPP",
+        "notes": "Add eccentric pull"
+      },
+      {
+        "name": "Wall-Supported External Rotation",
+        "phase": "SPP",
+        "notes": "Load tempo work"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pendulum Circles",
+        "phase": "TAPER",
+        "notes": "Drain lymph without active load"
+      },
+      {
+        "name": "Passive Overhead Stick Stretch",
+        "phase": "TAPER",
+        "notes": "Elevation with decompression (anterior deltoid)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Dumbbell Raises (Lateral Head)",
+        "phase": "GPP",
+        "notes": "Rebuild tendon load tolerance"
+      },
+      {
+        "name": "Banded Scaption Holds",
+        "phase": "GPP",
+        "notes": "Isolate supraspinatus"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Dumbbell Raises (Lateral Head)",
+        "phase": "SPP",
+        "notes": "Increase volume"
+      },
+      {
+        "name": "Banded Scaption Holds",
+        "phase": "SPP",
+        "notes": "Add resistance"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Dumbbell Raises (Lateral Head)",
+        "phase": "TAPER",
+        "notes": "Maintain sharpness"
+      },
+      {
+        "name": "Banded Scaption Holds",
+        "phase": "TAPER",
+        "notes": "Short holds for priming"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slide + Isometric Pause",
+        "phase": "GPP",
+        "notes": "Control end range of shoulder extension"
+      },
+      {
+        "name": "Resistance Band Reverse Fly",
+        "phase": "GPP",
+        "notes": "Posterior reactivation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slide + Isometric Pause",
+        "phase": "SPP",
+        "notes": "Advance to landmine presses"
+      },
+      {
+        "name": "Resistance Band Reverse Fly",
+        "phase": "SPP",
+        "notes": "Build power through range"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "YTW Raise Sequence (Light DBs)",
+        "phase": "GPP",
+        "notes": "Full-spectrum cuff stimulus"
+      },
+      {
+        "name": "Isometric Overhead Wall Push",
+        "phase": "GPP",
+        "notes": "Vertical tolerance"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "YTW Raise Sequence (Light DBs)",
+        "phase": "TAPER",
+        "notes": "Active recovery"
+      },
+      {
+        "name": "Isometric Overhead Wall Push",
+        "phase": "TAPER",
+        "notes": "Maintain overhead readiness"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "PVC Pass-Throughs",
+        "phase": "GPP",
+        "notes": "Open shoulder capsule and anterior chain"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Band",
+        "phase": "SPP",
+        "notes": "Reinforce upward rotation through serratus (posterior chain)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Press (90\u00b0 Abduction)",
+        "phase": "GPP",
+        "notes": "Reinforce static mid-range control (lateral deltoid)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Y-Raise",
+        "phase": "SPP",
+        "notes": "Target overhead tissue resilience (posterior & lateral)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sleeper Stretch on Wall",
+        "phase": "GPP",
+        "notes": "Improve posterior capsule glide"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun Sweep \u2013 Rear Deltoid",
+        "phase": "TAPER",
+        "notes": "Downregulate tone in posterior deltoid"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Angels (Floor Version if Needed)",
+        "phase": "SPP",
+        "notes": "Low-load reactivation of full chain (posterior + lateral)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Overhead Isometric Hold with Band",
+        "phase": "TAPER",
+        "notes": "Reinforce pain-free tension for anterior deltoid"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Roll with Lacrosse Ball",
+        "phase": "GPP",
+        "notes": "Break up bruising in anterior/lateral deltoid"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded IR/ER Light Pulses",
+        "phase": "SPP",
+        "notes": "Reintroduce active motion control without load"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "90/90 External Rotation Holds",
+        "phase": "GPP",
+        "notes": "Strengthen rotator cuff under mild sprain (posterior)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Overhead Scapular Pull-Aparts",
+        "phase": "SPP",
+        "notes": "Retrain stabilizers to handle overhead motion"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Passive Arm Circles",
+        "phase": "TAPER",
+        "notes": "Promote blood flow and lymph drainage"
+      },
+      {
+        "name": "Band Traction \u2013 Inferior Glide",
+        "phase": "TAPER",
+        "notes": "Create space in GH joint and reduce pressure"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Front Raises (Slow Lower)",
+        "phase": "GPP",
+        "notes": "Target long head of biceps / anterior deltoid loading"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Prone Y to W Raise",
+        "phase": "SPP",
+        "notes": "Develop scapular timing"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Prone Y to W Raise",
+        "phase": "TAPER",
+        "notes": "Maintain low-volume control"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall-Facing Shoulder CARs",
+        "phase": "GPP",
+        "notes": "Restore shoulder capsule control (anterior line)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bottoms-Up Kettlebell Hold (Elbow Bent)",
+        "phase": "SPP",
+        "notes": "Stabilize shoulder through controlled load (posterior chain)"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quadruped Weight Shifts (Arm Reaches)",
+        "phase": "GPP",
+        "notes": "Rebuild co-contraction and reflexive control"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Overhead Carries",
+        "phase": "SPP",
+        "notes": "Reinforce stability under movement"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Overhead Carries",
+        "phase": "TAPER",
+        "notes": "Lighter reps, shorter duration"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lateral Raise Isometric at 45\u00b0",
+        "phase": "TAPER",
+        "notes": "Maintain deltoid tone under low fatigue"
+      },
+      {
+        "name": "Soft Ball Wall Roll (Posterior Shoulder)",
+        "phase": "TAPER",
+        "notes": "Target rear deltoid tension release"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Push-Up Hold at Bottom Range",
+        "phase": "GPP",
+        "notes": "Safely reintroduce anterior load"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band Resisted Horizontal Pressouts",
+        "phase": "SPP",
+        "notes": "Increase anterior chain control post-extension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Bicep Curl Hold (Mid-Range)",
+        "phase": "GPP",
+        "notes": "Reinforce tendon tension at shortened length"
+      },
+      {
+        "name": "Band-Resisted Eccentric Curl",
+        "phase": "GPP",
+        "notes": "Control elongation under low load"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Bicep Curl Hold (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Transition into dynamic curl variations"
+      },
+      {
+        "name": "Band-Resisted Eccentric Curl",
+        "phase": "SPP",
+        "notes": "Add reps or tempo drag"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Bicep Isometric (Straight Arm)",
+        "phase": "SPP",
+        "notes": "Reduce tendon sensitivity"
+      },
+      {
+        "name": "Triceps Stretch with Shoulder Extension",
+        "phase": "SPP",
+        "notes": "Offload anterior shoulder tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Bicep Isometric (Straight Arm)",
+        "phase": "TAPER",
+        "notes": "Maintain readiness with minimal load"
+      },
+      {
+        "name": "Triceps Stretch with Shoulder Extension",
+        "phase": "TAPER",
+        "notes": "Balance flexor\u2013extensor tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roll \u2013 Bicep Line",
+        "phase": "GPP",
+        "notes": "Release fascial knots"
+      },
+      {
+        "name": "Banded Arm Extension Stretch",
+        "phase": "GPP",
+        "notes": "Open long head"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Foam Roll \u2013 Bicep Line",
+        "phase": "SPP",
+        "notes": "Use pre-session for mobility prep"
+      },
+      {
+        "name": "Banded Arm Extension Stretch",
+        "phase": "SPP",
+        "notes": "Load into extension before dynamic drills"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lacrosse Ball Compression (Distal Bicep)",
+        "phase": "TAPER",
+        "notes": "Flush DOMS and restore elbow mobility"
+      },
+      {
+        "name": "Active Supination + Elbow Flexion",
+        "phase": "TAPER",
+        "notes": "Retain contractile control with minimal load"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Gentle Arm Swings (Neutral Grip)",
+        "phase": "GPP",
+        "notes": "Restore blood flow with low strain"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Bicep Belly",
+        "phase": "GPP",
+        "notes": "Target contact desensitization"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Gentle Arm Swings (Neutral Grip)",
+        "phase": "SPP",
+        "notes": "Add ROM speed to test tolerance"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Bicep Belly",
+        "phase": "SPP",
+        "notes": "Prep tissue pre-load"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Incline DB Curl (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "Emphasize controlled stretch"
+      },
+      {
+        "name": "Banded Shoulder Flexion with Supination",
+        "phase": "GPP",
+        "notes": "Train full-line tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Incline DB Curl (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Add volume load"
+      },
+      {
+        "name": "Banded Shoulder Flexion with Supination",
+        "phase": "SPP",
+        "notes": "Reinforce shoulder-elbow control"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Incline DB Curl (Eccentric Focus)",
+        "phase": "TAPER",
+        "notes": "Reduce load, maintain ROM"
+      },
+      {
+        "name": "Banded Shoulder Flexion with Supination",
+        "phase": "TAPER",
+        "notes": "Maintain coordination"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Zottman Curl (Band)",
+        "phase": "GPP",
+        "notes": "Train elbow under rotation"
+      },
+      {
+        "name": "Grip Trainer Squeeze + Hold",
+        "phase": "GPP",
+        "notes": "Isolate elbow stabilizers"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Light Zottman Curl (Band)",
+        "phase": "SPP",
+        "notes": "Increase control under pronation stress"
+      },
+      {
+        "name": "Grip Trainer Squeeze + Hold",
+        "phase": "SPP",
+        "notes": "Integrate forearm with bicep recoil"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Band Pull-Apart",
+        "phase": "GPP",
+        "notes": "Reinforce scapular mechanics"
+      },
+      {
+        "name": "Bottom-Up Kettlebell Curl",
+        "phase": "GPP",
+        "notes": "Enforce joint control through wrist/elbow"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slides with Band Pull-Apart",
+        "phase": "SPP",
+        "notes": "Load bicep safely in clean range"
+      },
+      {
+        "name": "Bottom-Up Kettlebell Curl",
+        "phase": "SPP",
+        "notes": "Add tempo for eccentric integrity"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chaos Band Curl",
+        "phase": "SPP",
+        "notes": "Build reactive elbow control"
+      },
+      {
+        "name": "Hammer Curl Isometric Pulse",
+        "phase": "SPP",
+        "notes": "Maintain mid-range tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Chaos Band Curl",
+        "phase": "TAPER",
+        "notes": "Sharpen tension in unstable angles"
+      },
+      {
+        "name": "Hammer Curl Isometric Pulse",
+        "phase": "TAPER",
+        "notes": "Preserve CNS tone with no joint threat"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Arm Elevation with Active Wrist Pumps",
+        "phase": "TAPER",
+        "notes": "Promote drainage via venous return"
+      },
+      {
+        "name": "Forearm Supination\u2013Pronation Waves",
+        "phase": "TAPER",
+        "notes": "Gentle flush through elbow\u2013bicep track"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Stick Shoulder Dislocates",
+        "phase": "GPP",
+        "notes": "Restore anterior line range"
+      },
+      {
+        "name": "Standing Arm Opener (Wall Anchor)",
+        "phase": "GPP",
+        "notes": "Reset capsule glide"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Stick Shoulder Dislocates",
+        "phase": "TAPER",
+        "notes": "Maintain freedom under no load"
+      },
+      {
+        "name": "Standing Arm Opener (Wall Anchor)",
+        "phase": "TAPER",
+        "notes": "Use for daily ROM preservation"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Controlled Elbow Extension",
+        "phase": "GPP",
+        "notes": "Teach terminal control"
+      },
+      {
+        "name": "Wall Push-Up Iso (Soft Elbow Lock)",
+        "phase": "GPP",
+        "notes": "Load joint gradually"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Controlled Elbow Extension",
+        "phase": "SPP",
+        "notes": "Add volume under slow decel"
+      },
+      {
+        "name": "Wall Push-Up Iso (Soft Elbow Lock)",
+        "phase": "SPP",
+        "notes": "Tolerate speed in extension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bicep Wall Stretch (Wrist Supinated)",
+        "phase": "GPP",
+        "notes": "Open anterior chain safely"
+      },
+      {
+        "name": "Suspension Curl (TRX or Rings)",
+        "phase": "GPP",
+        "notes": "Adjust difficulty via angle"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bicep Wall Stretch (Wrist Supinated)",
+        "phase": "SPP",
+        "notes": "Transition into active ROM drills"
+      },
+      {
+        "name": "Suspension Curl (TRX or Rings)",
+        "phase": "SPP",
+        "notes": "Add holds at weak points"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Gentle Arm Circles (Neutral)",
+        "phase": "TAPER",
+        "notes": "Restore mobility and blood flow"
+      },
+      {
+        "name": "Soft Tissue Glide \u2013 Massage Stick",
+        "phase": "TAPER",
+        "notes": "Downregulate tension pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cable Curl with Fat Grip",
+        "phase": "SPP",
+        "notes": "Load eccentric under control"
+      },
+      {
+        "name": "Supinated Isometric Elbow Hold",
+        "phase": "SPP",
+        "notes": "Hold mid-flexion tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Cable Curl with Fat Grip",
+        "phase": "TAPER",
+        "notes": "Drop volume but keep tension sharp"
+      },
+      {
+        "name": "Supinated Isometric Elbow Hold",
+        "phase": "TAPER",
+        "notes": "Maintain capacity without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Triceps Press",
+        "phase": "GPP",
+        "notes": "Rebuild base triceps tension"
+      },
+      {
+        "name": "Overhead Band Triceps Extensions",
+        "phase": "GPP",
+        "notes": "Light end-range loading"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Triceps Press",
+        "phase": "SPP",
+        "notes": "Increase time under tension to restore punch extension"
+      },
+      {
+        "name": "Overhead Band Triceps Extensions",
+        "phase": "SPP",
+        "notes": "Progress to controlled eccentric"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Triceps Wall Stretch",
+        "phase": "GPP",
+        "notes": "Open up posterior shoulder line"
+      },
+      {
+        "name": "Foam Roll \u2013 Long Head Sweep",
+        "phase": "GPP",
+        "notes": "Loosen fascial chain"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Triceps Wall Stretch",
+        "phase": "TAPER",
+        "notes": "Use post-session to reduce neural tension"
+      },
+      {
+        "name": "Foam Roll \u2013 Long Head Sweep",
+        "phase": "TAPER",
+        "notes": "Target lateral head for lockout fluidity"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Pushdowns",
+        "phase": "GPP",
+        "notes": "Reload tendon at low intensity"
+      },
+      {
+        "name": "Kneeling Cable Extensions (Single Arm)",
+        "phase": "GPP",
+        "notes": "Reinforce control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Band Pushdowns",
+        "phase": "SPP",
+        "notes": "Add volume to rebuild durability"
+      },
+      {
+        "name": "Kneeling Cable Extensions (Single Arm)",
+        "phase": "SPP",
+        "notes": "Scale tension safely"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Band Pushdowns",
+        "phase": "TAPER",
+        "notes": "Reduce to isometrics only"
+      },
+      {
+        "name": "Kneeling Cable Extensions (Single Arm)",
+        "phase": "TAPER",
+        "notes": "Maintain pain-free output"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Shoulder Flexion Slide",
+        "phase": "GPP",
+        "notes": "Re-establish triceps clearance through flexion"
+      },
+      {
+        "name": "Wall Clock Mobility (Straight Arm)",
+        "phase": "GPP",
+        "notes": "Mobilize long head at overhead range"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Shoulder Flexion Slide",
+        "phase": "SPP",
+        "notes": "Add tension to replicate extension path"
+      },
+      {
+        "name": "Wall Clock Mobility (Straight Arm)",
+        "phase": "SPP",
+        "notes": "Anchor scapular control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "swelling",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Elevated Arm Pulses (Palm Down)",
+        "phase": "GPP",
+        "notes": "Pump lymph through posterior arm"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Posterior Arm",
+        "phase": "GPP",
+        "notes": "Flush congestion from distal insertion"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Arm Pulses (Palm Down)",
+        "phase": "TAPER",
+        "notes": "Maintain tone with minimal CNS load"
+      },
+      {
+        "name": "Massage Gun Sweep \u2013 Posterior Arm",
+        "phase": "TAPER",
+        "notes": "Target medial head flare"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Light Band Kickbacks",
+        "phase": "TAPER",
+        "notes": "Flow triceps through low-resistance reps"
+      },
+      {
+        "name": "Straight Arm Downward Swings",
+        "phase": "TAPER",
+        "notes": "Pump blood flow and prep extension pattern"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Assisted Straight-Arm Plank",
+        "phase": "GPP",
+        "notes": "Static brace"
+      },
+      {
+        "name": "Overhead Dumbbell Triceps Extensions",
+        "phase": "GPP",
+        "notes": "Rebuild stretch tolerance"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Assisted Straight-Arm Plank",
+        "phase": "SPP",
+        "notes": "Load under shoulder extension safely"
+      },
+      {
+        "name": "Overhead Dumbbell Triceps Extensions",
+        "phase": "SPP",
+        "notes": "Increase tempo under control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neutral-Grip Cable Extensions",
+        "phase": "SPP",
+        "notes": "Mid-range output with low strain"
+      },
+      {
+        "name": "Isometric Triceps Bridge (Wall Hold)",
+        "phase": "SPP",
+        "notes": "Rebuild stability"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neutral-Grip Cable Extensions",
+        "phase": "TAPER",
+        "notes": "Maintain groove without locking out"
+      },
+      {
+        "name": "Isometric Triceps Bridge (Wall Hold)",
+        "phase": "TAPER",
+        "notes": "Sustain tone under zero motion"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Triceps Band Oscillations",
+        "phase": "SPP",
+        "notes": "Train reflex control"
+      },
+      {
+        "name": "Wall Triceps Press in Split Stance",
+        "phase": "SPP",
+        "notes": "Anchor full-chain control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Triceps Band Oscillations",
+        "phase": "TAPER",
+        "notes": "Reduce amplitude for activation"
+      },
+      {
+        "name": "Wall Triceps Press in Split Stance",
+        "phase": "TAPER",
+        "notes": "Lock pattern into warmup flow"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Vibration (Ball)",
+        "phase": "GPP",
+        "notes": "Reduce tenderness post-contact"
+      },
+      {
+        "name": "Wall Assisted Arm Circles",
+        "phase": "GPP",
+        "notes": "Reintroduce motion safely"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Vibration (Ball)",
+        "phase": "SPP",
+        "notes": "Integrate with stretch hold"
+      },
+      {
+        "name": "Wall Assisted Arm Circles",
+        "phase": "SPP",
+        "notes": "Add overhead control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Triceps Band Recoil Drill",
+        "phase": "GPP",
+        "notes": "Limit ROM to protect elbow"
+      },
+      {
+        "name": "TRX Elbow Press Downs",
+        "phase": "GPP",
+        "notes": "Anchor eccentric finish"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Triceps Band Recoil Drill",
+        "phase": "SPP",
+        "notes": "Add reflex control"
+      },
+      {
+        "name": "TRX Elbow Press Downs",
+        "phase": "SPP",
+        "notes": "Advance with tempo"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Press with Band",
+        "phase": "GPP",
+        "notes": "Light press activation"
+      },
+      {
+        "name": "Floor Triceps Push (Controlled)",
+        "phase": "GPP",
+        "notes": "Limit strain at top range"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Press with Band",
+        "phase": "SPP",
+        "notes": "Add horizontal load"
+      },
+      {
+        "name": "Floor Triceps Push (Controlled)",
+        "phase": "SPP",
+        "notes": "Add volume for tolerance"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slides (Overhead Elbow Flexed)",
+        "phase": "GPP",
+        "notes": "Mobilize long head"
+      },
+      {
+        "name": "Band Elbow Opener",
+        "phase": "GPP",
+        "notes": "Target posterior arm length"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Slides (Overhead Elbow Flexed)",
+        "phase": "TAPER",
+        "notes": "Maintain overhead position"
+      },
+      {
+        "name": "Band Elbow Opener",
+        "phase": "TAPER",
+        "notes": "Keep end range"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Push-Up to Tabletop Flow",
+        "phase": "SPP",
+        "notes": "Blend flexion-extension under rhythm"
+      },
+      {
+        "name": "Kettlebell Crush Press (Light)",
+        "phase": "SPP",
+        "notes": "Load medial head under control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Push-Up to Tabletop Flow",
+        "phase": "TAPER",
+        "notes": "Reduce to tension resets"
+      },
+      {
+        "name": "Kettlebell Crush Press (Light)",
+        "phase": "TAPER",
+        "notes": "Maintain groove"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Overhead Rope Stretch",
+        "phase": "SPP",
+        "notes": "Open line through lat and triceps"
+      },
+      {
+        "name": "Stick Triceps Opener (Elbow Up)",
+        "phase": "SPP",
+        "notes": "Target fascia through arm path"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Overhead Rope Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain end range"
+      },
+      {
+        "name": "Stick Triceps Opener (Elbow Up)",
+        "phase": "TAPER",
+        "notes": "Use for recovery"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Curls (Slow Tempo)",
+        "phase": "GPP",
+        "notes": "Restore concentric strength"
+      },
+      {
+        "name": "Finger Extension Band Flicks",
+        "phase": "GPP",
+        "notes": "Target extensors gently"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Curls (Slow Tempo)",
+        "phase": "SPP",
+        "notes": "Add eccentric tempo for durability"
+      },
+      {
+        "name": "Finger Extension Band Flicks",
+        "phase": "SPP",
+        "notes": "Integrate into grip reset"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Forearm Flexor Stretch (Wall)",
+        "phase": "GPP",
+        "notes": "Restore anterior line length"
+      },
+      {
+        "name": "Massage Gun Sweep (Flexor Mass)",
+        "phase": "GPP",
+        "notes": "Downregulate tension"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Forearm Flexor Stretch (Wall)",
+        "phase": "TAPER",
+        "notes": "Use pre-comp to free wrist glide"
+      },
+      {
+        "name": "Massage Gun Sweep (Flexor Mass)",
+        "phase": "TAPER",
+        "notes": "Flush local tissue pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "soreness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Passive Wrist Circles (Tabletop Support)",
+        "phase": "SPP",
+        "notes": "Maintain range without loading"
+      },
+      {
+        "name": "Rice Bucket Twists",
+        "phase": "SPP",
+        "notes": "Light endurance stimulus"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Passive Wrist Circles (Tabletop Support)",
+        "phase": "TAPER",
+        "notes": "Gentle recovery"
+      },
+      {
+        "name": "Rice Bucket Twists",
+        "phase": "TAPER",
+        "notes": "Maintain mobility + heat"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Neutral Hold (Dumbbell)",
+        "phase": "GPP",
+        "notes": "Avoid joint motion"
+      },
+      {
+        "name": "Towel Twists (Isometric)",
+        "phase": "GPP",
+        "notes": "Isolate torsion safely"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Neutral Hold (Dumbbell)",
+        "phase": "SPP",
+        "notes": "Add time under tension for grip"
+      },
+      {
+        "name": "Towel Twists (Isometric)",
+        "phase": "SPP",
+        "notes": "Build tolerance gradually"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Controlled Wrist CARs",
+        "phase": "GPP",
+        "notes": "Restore capsule glide"
+      },
+      {
+        "name": "Wrist Wave Mobility (Stick Roll)",
+        "phase": "GPP",
+        "notes": "Coordinate full wrist path"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Controlled Wrist CARs",
+        "phase": "SPP",
+        "notes": "Add banded distraction or control"
+      },
+      {
+        "name": "Wrist Wave Mobility (Stick Roll)",
+        "phase": "SPP",
+        "notes": "Add tempo or pause"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Circles (Forearm Ball)",
+        "phase": "GPP",
+        "notes": "Desensitize bruised muscle belly"
+      },
+      {
+        "name": "Wrist Extensor Light Activation (Theraband)",
+        "phase": "GPP",
+        "notes": "Restore light contractile flow post-contact"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Flexion Stretch (Palm Down, Elbow Extended)",
+        "phase": "GPP",
+        "notes": "Light stretch for ligaments"
+      },
+      {
+        "name": "Forearm Pronation/Supination Isos",
+        "phase": "GPP",
+        "notes": "Rebuild joint range"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Flexion Stretch (Palm Down, Elbow Extended)",
+        "phase": "SPP",
+        "notes": "Add control or resisted holds"
+      },
+      {
+        "name": "Forearm Pronation/Supination Isos",
+        "phase": "SPP",
+        "notes": "Advance control under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensions",
+        "phase": "GPP",
+        "notes": "Load extensors eccentrically"
+      },
+      {
+        "name": "Reverse Curls (Light Load)",
+        "phase": "GPP",
+        "notes": "Isolate extensor-brachioradialis"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensions",
+        "phase": "SPP",
+        "notes": "Tolerate light reps"
+      },
+      {
+        "name": "Reverse Curls (Light Load)",
+        "phase": "SPP",
+        "notes": "Build volume safely"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensions",
+        "phase": "TAPER",
+        "notes": "Maintain grip pain-free"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hammer Grip Wrist Holds (Bottom-Up KB)",
+        "phase": "SPP",
+        "notes": "Rebuild joint stability"
+      },
+      {
+        "name": "Wrist Roller (Over/Underhand Alternation)",
+        "phase": "SPP",
+        "notes": "Dynamic grip challenge"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Hammer Grip Wrist Holds (Bottom-Up KB)",
+        "phase": "TAPER",
+        "notes": "Maintain control in fast motions"
+      },
+      {
+        "name": "Wrist Roller (Over/Underhand Alternation)",
+        "phase": "TAPER",
+        "notes": "Use shorter reps for control"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Assisted Wrist Traction",
+        "phase": "GPP",
+        "notes": "Restore joint space and glide"
+      },
+      {
+        "name": "Isometric Wrist Holds (End-Range Flex/Ext)",
+        "phase": "GPP",
+        "notes": "Control end-range tension"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Assisted Wrist Traction",
+        "phase": "SPP",
+        "notes": "Maintain with light activation"
+      },
+      {
+        "name": "Isometric Wrist Holds (End-Range Flex/Ext)",
+        "phase": "SPP",
+        "notes": "Use angles under light load"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Wrist Pumps",
+        "phase": "TAPER",
+        "notes": "Flush residual fluid with elevation and pulse"
+      },
+      {
+        "name": "Gentle Finger Flicks",
+        "phase": "TAPER",
+        "notes": "Promote drainage while keeping grip awake"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Stability Drill on BOSU Ball",
+        "phase": "GPP",
+        "notes": "Restore proprioceptive tolerance"
+      },
+      {
+        "name": "Palm-Down Crawls",
+        "phase": "GPP",
+        "notes": "Light extension loading"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Stability Drill on BOSU Ball",
+        "phase": "SPP",
+        "notes": "Progress to loaded plank positions"
+      },
+      {
+        "name": "Palm-Down Crawls",
+        "phase": "SPP",
+        "notes": "Integrate across kinetic chain"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Open-Close Grip Endurance Drill",
+        "phase": "GPP",
+        "notes": "Light activation across forearm groups"
+      },
+      {
+        "name": "Stick Rotations (Forearm Twist)",
+        "phase": "GPP",
+        "notes": "General mobility and endurance"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Open-Close Grip Endurance Drill",
+        "phase": "TAPER",
+        "notes": "Maintain responsiveness"
+      },
+      {
+        "name": "Stick Rotations (Forearm Twist)",
+        "phase": "TAPER",
+        "notes": "Sharpness with no load"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun on Flexors/Extensors",
+        "phase": "TAPER",
+        "notes": "Loosen up post-grip volume"
+      },
+      {
+        "name": "Light Squeeze Ball Reps",
+        "phase": "TAPER",
+        "notes": "Wake up forearm tone without tension"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Forearm Floss",
+        "phase": "GPP",
+        "notes": "Restore soft tissue glide"
+      },
+      {
+        "name": "Forearm Twists with Light Plate",
+        "phase": "GPP",
+        "notes": "Mobilize grip rotation"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Forearm Floss",
+        "phase": "SPP",
+        "notes": "Maintain pliability under stress"
+      },
+      {
+        "name": "Forearm Twists with Light Plate",
+        "phase": "SPP",
+        "notes": "Add duration and load"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Elbow Flexion Hold (90\u00b0)",
+        "phase": "GPP",
+        "notes": "Restore safe contractile tension"
+      },
+      {
+        "name": "Pronation/Supination with Light Dumbbell",
+        "phase": "GPP",
+        "notes": "Restore rotational control"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Elbow Flexion Hold (90\u00b0)",
+        "phase": "SPP",
+        "notes": "Add banded resistance or hold under load"
+      },
+      {
+        "name": "Pronation/Supination with Light Dumbbell",
+        "phase": "SPP",
+        "notes": "Integrate into speed under resistance"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Wall Slides (Elbow Straight)",
+        "phase": "GPP",
+        "notes": "Activate stabilizers without load"
+      },
+      {
+        "name": "Overhead Band Triceps Extension",
+        "phase": "GPP",
+        "notes": "Rebuild overhead stability"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Wall Slides (Elbow Straight)",
+        "phase": "SPP",
+        "notes": "Advance to cable tricep or bicep reintroduction"
+      },
+      {
+        "name": "Overhead Band Triceps Extension",
+        "phase": "SPP",
+        "notes": "Add tempo for load tolerance"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Forearm Wall Slides",
+        "phase": "GPP",
+        "notes": "Mobilize flexor tendon line"
+      },
+      {
+        "name": "Massage Gun Sweep (Medial Elbow)",
+        "phase": "GPP",
+        "notes": "Reduce fascial restriction"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Forearm Wall Slides",
+        "phase": "TAPER",
+        "notes": "Maintain capsule glide without stress"
+      },
+      {
+        "name": "Massage Gun Sweep (Medial Elbow)",
+        "phase": "TAPER",
+        "notes": "Use before sparring for fluid range"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neutral Grip DB Curls (Isometric)",
+        "phase": "SPP",
+        "notes": "Minimize joint strain while restoring load"
+      },
+      {
+        "name": "Wall Press Iso at 90\u00b0 Elbow Flexion",
+        "phase": "SPP",
+        "notes": "Static control with low irritation"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neutral Grip DB Curls (Isometric)",
+        "phase": "TAPER",
+        "notes": "Maintain activation under low fatigue"
+      },
+      {
+        "name": "Wall Press Iso at 90\u00b0 Elbow Flexion",
+        "phase": "TAPER",
+        "notes": "CNS-safe tension before fight"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Reverse Wrist Curls",
+        "phase": "GPP",
+        "notes": "Load tendon with slow eccentrics"
+      },
+      {
+        "name": "Banded Tricep Extensions",
+        "phase": "GPP",
+        "notes": "Reintroduce tendon tension safely"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Reverse Wrist Curls",
+        "phase": "SPP",
+        "notes": "Increase load and speed"
+      },
+      {
+        "name": "Banded Tricep Extensions",
+        "phase": "SPP",
+        "notes": "Sharpen with explosive finish"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Reverse Wrist Curls",
+        "phase": "TAPER",
+        "notes": "Drop volume, retain range"
+      },
+      {
+        "name": "Banded Tricep Extensions",
+        "phase": "TAPER",
+        "notes": "Maintain groove with minimal load"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Overhead Elbow Pumps (Band-Assisted)",
+        "phase": "TAPER",
+        "notes": "Flush inflammation with passive motion"
+      },
+      {
+        "name": "Compression Wrap + Elevation Drill",
+        "phase": "TAPER",
+        "notes": "Reduce pooling and boost blood flow pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Elbow CARs",
+        "phase": "GPP",
+        "notes": "Restore end-range control"
+      },
+      {
+        "name": "Banded Elbow Distraction",
+        "phase": "GPP",
+        "notes": "Open joint space"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Elbow CARs",
+        "phase": "SPP",
+        "notes": "Integrate with loaded control"
+      },
+      {
+        "name": "Banded Elbow Distraction",
+        "phase": "SPP",
+        "notes": "Maintain mobility under banded control"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Closed-Chain Rock-Backs (Elbow Under Shoulder)",
+        "phase": "SPP",
+        "notes": "Rebuild stable joint under light motion"
+      },
+      {
+        "name": "Mini Band Triceps Kickbacks",
+        "phase": "SPP",
+        "notes": "Reintegrate elbow extension control"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Closed-Chain Rock-Backs (Elbow Under Shoulder)",
+        "phase": "TAPER",
+        "notes": "Maintain control in neutral zones"
+      },
+      {
+        "name": "Mini Band Triceps Kickbacks",
+        "phase": "TAPER",
+        "notes": "Sharpen light punch follow-through"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lacrosse Ball Forearm/Elbow Floss",
+        "phase": "TAPER",
+        "notes": "Clear tight tissue pre-spar"
+      },
+      {
+        "name": "Cable Low-Tension Curls (Long ROM)",
+        "phase": "TAPER",
+        "notes": "Mobilize and activate without overload"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Active Elbow Flexion/Extension with Dowel",
+        "phase": "GPP",
+        "notes": "Restore joint rhythm"
+      },
+      {
+        "name": "Wrist-to-Shoulder Slides on Wall",
+        "phase": "GPP",
+        "notes": "Coordinate upper limb motion"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Active Elbow Flexion/Extension with Dowel",
+        "phase": "SPP",
+        "notes": "Reinforce ROM under light resistance"
+      },
+      {
+        "name": "Wrist-to-Shoulder Slides on Wall",
+        "phase": "SPP",
+        "notes": "Add tempo or band"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Elbow Stop Holds (Band Behind Elbow)",
+        "phase": "GPP",
+        "notes": "Train end-range defense"
+      },
+      {
+        "name": "Wall Press Partial Range Extensions",
+        "phase": "GPP",
+        "notes": "Restore controlled ROM"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Elbow Stop Holds (Band Behind Elbow)",
+        "phase": "SPP",
+        "notes": "Build reflex and endurance"
+      },
+      {
+        "name": "Wall Press Partial Range Extensions",
+        "phase": "SPP",
+        "notes": "Add depth gradually"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Gentle Elbow Slides on Wall",
+        "phase": "GPP",
+        "notes": "Rebuild contact tolerance"
+      },
+      {
+        "name": "Massage Gun Pass (Lateral Elbow)",
+        "phase": "GPP",
+        "notes": "Break up surface inflammation"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Gentle Elbow Slides on Wall",
+        "phase": "SPP",
+        "notes": "Reintegrate into pushing mechanics"
+      },
+      {
+        "name": "Massage Gun Pass (Lateral Elbow)",
+        "phase": "SPP",
+        "notes": "Layer into isometric prep"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neutral Grip Isometric Holds",
+        "phase": "GPP",
+        "notes": "Non-irritating load entry"
+      },
+      {
+        "name": "Arm Bar Stretch (Modified)",
+        "phase": "GPP",
+        "notes": "Light capsule opening"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neutral Grip Isometric Holds",
+        "phase": "TAPER",
+        "notes": "Safe retention of movement pattern"
+      },
+      {
+        "name": "Arm Bar Stretch (Modified)",
+        "phase": "TAPER",
+        "notes": "Calm passive mobility"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Wrist Press",
+        "phase": "GPP",
+        "notes": "Load ligament gently"
+      },
+      {
+        "name": "Band-Assisted Wrist Flexion Hold",
+        "phase": "GPP",
+        "notes": "Safe end-range control"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Wrist Press",
+        "phase": "SPP",
+        "notes": "Add slight range to simulate punch guard"
+      },
+      {
+        "name": "Band-Assisted Wrist Flexion Hold",
+        "phase": "SPP",
+        "notes": "Add time-under-tension for guard resilience"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Curl (Light Dumbbell)",
+        "phase": "GPP",
+        "notes": "Rebuild flexor strength"
+      },
+      {
+        "name": "Reverse Wrist Curl",
+        "phase": "GPP",
+        "notes": "Activate extensors"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Curl (Light Dumbbell)",
+        "phase": "SPP",
+        "notes": "Add eccentric load to increase durability"
+      },
+      {
+        "name": "Reverse Wrist Curl",
+        "phase": "SPP",
+        "notes": "Add control under impact posture"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensor Drops",
+        "phase": "GPP",
+        "notes": "Begin tendon loading"
+      },
+      {
+        "name": "Theraband Forearm Waves",
+        "phase": "GPP",
+        "notes": "Stimulate tendon glide"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensor Drops",
+        "phase": "SPP",
+        "notes": "Increase reps"
+      },
+      {
+        "name": "Theraband Forearm Waves",
+        "phase": "SPP",
+        "notes": "Build endurance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Extensor Drops",
+        "phase": "TAPER",
+        "notes": "Maintain tone pre-fight"
+      },
+      {
+        "name": "Theraband Forearm Waves",
+        "phase": "TAPER",
+        "notes": "Short reps for prep"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Flexor Stretch (Palm Up, Wall)",
+        "phase": "GPP",
+        "notes": "Open anterior wrist line"
+      },
+      {
+        "name": "Extensor Stretch (Palm Down)",
+        "phase": "GPP",
+        "notes": "Release posterior chain"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Flexor Stretch (Palm Up, Wall)",
+        "phase": "TAPER",
+        "notes": "Maintain mobility pre-session"
+      },
+      {
+        "name": "Extensor Stretch (Palm Down)",
+        "phase": "TAPER",
+        "notes": "Keep free before sparring"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Radial/Ulnar Deviation Isos",
+        "phase": "GPP",
+        "notes": "Restore joint space"
+      },
+      {
+        "name": "Wrist Distraction with Band",
+        "phase": "GPP",
+        "notes": "Unload joint"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Radial/Ulnar Deviation Isos",
+        "phase": "SPP",
+        "notes": "Load under function"
+      },
+      {
+        "name": "Wrist Distraction with Band",
+        "phase": "SPP",
+        "notes": "Maintain glide under compression"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Push-Ups (Knees \u2192 Full)",
+        "phase": "GPP",
+        "notes": "Proprioceptive loading"
+      },
+      {
+        "name": "Knuckle Push-Ups",
+        "phase": "GPP",
+        "notes": "Rebuild strike alignment"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Push-Ups (Knees \u2192 Full)",
+        "phase": "SPP",
+        "notes": "Increase load"
+      },
+      {
+        "name": "Knuckle Push-Ups",
+        "phase": "SPP",
+        "notes": "Add depth"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wrist Push-Ups (Knees \u2192 Full)",
+        "phase": "TAPER",
+        "notes": "Maintain readiness"
+      },
+      {
+        "name": "Knuckle Push-Ups",
+        "phase": "TAPER",
+        "notes": "Low-volume reactivator"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Wrist Pumps",
+        "phase": "TAPER",
+        "notes": "Drain inflammation pre-fight"
+      },
+      {
+        "name": "Gentle Wrist Circles (Slow)",
+        "phase": "TAPER",
+        "notes": "Maintain mobility without strain"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun Sweep Along Wrist",
+        "phase": "TAPER",
+        "notes": "Flush DOMS post-heavy gripping"
+      },
+      {
+        "name": "Soft Rice Bucket Twists",
+        "phase": "TAPER",
+        "notes": "Release tension while working grip"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist CARs",
+        "phase": "GPP",
+        "notes": "Restore capsule glide"
+      },
+      {
+        "name": "Stick Roll Wrist Flex/Ext",
+        "phase": "GPP",
+        "notes": "Mobilize fascial line"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist CARs",
+        "phase": "SPP",
+        "notes": "Add band for resistance"
+      },
+      {
+        "name": "Stick Roll Wrist Flex/Ext",
+        "phase": "SPP",
+        "notes": "Train control under load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Palmar Wrist Push",
+        "phase": "GPP",
+        "notes": "Defend end-range"
+      },
+      {
+        "name": "Wall-Assisted Knuckle Press",
+        "phase": "GPP",
+        "notes": "Anchor alignment"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Palmar Wrist Push",
+        "phase": "SPP",
+        "notes": "Add reflex under perturbation"
+      },
+      {
+        "name": "Wall-Assisted Knuckle Press",
+        "phase": "SPP",
+        "notes": "Reflex load for impact prep"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Glide with Ball",
+        "phase": "GPP",
+        "notes": "Desensitize contact site"
+      },
+      {
+        "name": "Wrist Flexion Extension Passes",
+        "phase": "GPP",
+        "notes": "Restore motion"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Glide with Ball",
+        "phase": "SPP",
+        "notes": "Reintroduce light load"
+      },
+      {
+        "name": "Wrist Flexion Extension Passes",
+        "phase": "SPP",
+        "notes": "Integrate joint into function"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Open-Close Grip Ball",
+        "phase": "GPP",
+        "notes": "General activation"
+      },
+      {
+        "name": "Wrist Roller Hold",
+        "phase": "GPP",
+        "notes": "Load endurance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Open-Close Grip Ball",
+        "phase": "TAPER",
+        "notes": "Maintain tension readiness"
+      },
+      {
+        "name": "Wrist Roller Hold",
+        "phase": "TAPER",
+        "notes": "Short sets for prep"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Dumbbell Wrist Hold (Neutral)",
+        "phase": "SPP",
+        "notes": "Controlled tension"
+      },
+      {
+        "name": "Forearm Supination/Pronation Paused",
+        "phase": "SPP",
+        "notes": "Reload torsion control"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Dumbbell Wrist Hold (Neutral)",
+        "phase": "TAPER",
+        "notes": "Light prepare prior to session"
+      },
+      {
+        "name": "Forearm Supination/Pronation Paused",
+        "phase": "TAPER",
+        "notes": "Retain mid-range readiness"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cable Reverse Curl (Eccentric)",
+        "phase": "SPP",
+        "notes": "Train controlled load"
+      },
+      {
+        "name": "Wrist Flexion Bear Hug Iso",
+        "phase": "SPP",
+        "notes": "Engage pistoning reflex"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Cable Reverse Curl (Eccentric)",
+        "phase": "TAPER",
+        "notes": "Maintain quality reps"
+      },
+      {
+        "name": "Wrist Flexion Bear Hug Iso",
+        "phase": "TAPER",
+        "notes": "Retain control under tension"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Stability Drill with Dynamometer",
+        "phase": "SPP",
+        "notes": "Test joint under load"
+      },
+      {
+        "name": "Band Stabilization Circles",
+        "phase": "SPP",
+        "notes": "Load end-range tension"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wrist Stability Drill with Dynamometer",
+        "phase": "TAPER",
+        "notes": "Maintain refined control"
+      },
+      {
+        "name": "Band Stabilization Circles",
+        "phase": "TAPER",
+        "notes": "Flash mobility without overdrive"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pronation/Supination Twists",
+        "phase": "SPP",
+        "notes": "Build torsion tolerance"
+      },
+      {
+        "name": "Light Thumb Opposition Drill",
+        "phase": "SPP",
+        "notes": "Engage decoupled tendon lines"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pronation/Supination Twists",
+        "phase": "TAPER",
+        "notes": "Short pulses for refresh"
+      },
+      {
+        "name": "Light Thumb Opposition Drill",
+        "phase": "TAPER",
+        "notes": "Maintain mobility"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wobble Board Wrist Balances",
+        "phase": "GPP",
+        "notes": "Proprioceptive reprogram"
+      },
+      {
+        "name": "Therapy Putty Grip Twists",
+        "phase": "GPP",
+        "notes": "Rebuild joint control"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wobble Board Wrist Balances",
+        "phase": "TAPER",
+        "notes": "Quick sharpeners"
+      },
+      {
+        "name": "Therapy Putty Grip Twists",
+        "phase": "TAPER",
+        "notes": "Maintain activation under low load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Extension Stretch (Elastic)",
+        "phase": "SPP",
+        "notes": "Restore finger-wrist glide"
+      },
+      {
+        "name": "Resisted Wrist Flexor Sweep",
+        "phase": "SPP",
+        "notes": "Maintain open tissue"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger Extension Stretch (Elastic)",
+        "phase": "TAPER",
+        "notes": "Short holds pre-session"
+      },
+      {
+        "name": "Resisted Wrist Flexor Sweep",
+        "phase": "TAPER",
+        "notes": "Light activation before fight"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Theraband Wrist Abduction/Adduction",
+        "phase": "SPP",
+        "notes": "Load rarely used axes"
+      },
+      {
+        "name": "Palm-March Wrist Stretch",
+        "phase": "SPP",
+        "notes": "Enhance flexor-chain glide"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Theraband Wrist Abduction/Adduction",
+        "phase": "TAPER",
+        "notes": "Short reps priming"
+      },
+      {
+        "name": "Palm-March Wrist Stretch",
+        "phase": "TAPER",
+        "notes": "Reset under no stress"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up to Partial Extension",
+        "phase": "SPP",
+        "notes": "Build guard reflex"
+      },
+      {
+        "name": "Isometric Dorsal Wrist Hold",
+        "phase": "SPP",
+        "notes": "Defend overextension"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "hyperextension",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up to Partial Extension",
+        "phase": "TAPER",
+        "notes": "Maintain for spar readiness"
+      },
+      {
+        "name": "Isometric Dorsal Wrist Hold",
+        "phase": "TAPER",
+        "notes": "Sustain under control"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Roller (Light Plate)",
+        "phase": "SPP",
+        "notes": "Restore controlled flexion/extension"
+      },
+      {
+        "name": "Farmer\u2019s Hold with Wrist Control",
+        "phase": "SPP",
+        "notes": "Build isometric grip"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wrist Roller (Light Plate)",
+        "phase": "TAPER",
+        "notes": "Use low load for coordination retention"
+      },
+      {
+        "name": "Farmer\u2019s Hold with Wrist Control",
+        "phase": "TAPER",
+        "notes": "Maintain under time constraints"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Flexion with Dumbbell",
+        "phase": "GPP",
+        "notes": "Control tendon loading"
+      },
+      {
+        "name": "Wrist Extensor Stretch (Palm Down)",
+        "phase": "GPP",
+        "notes": "Restore passive length"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Flexion with Dumbbell",
+        "phase": "SPP",
+        "notes": "Increase load tempo"
+      },
+      {
+        "name": "Wrist Extensor Stretch (Palm Down)",
+        "phase": "SPP",
+        "notes": "Hold under active load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Flexion with Dumbbell",
+        "phase": "TAPER",
+        "notes": "Maintain under time"
+      },
+      {
+        "name": "Wrist Extensor Stretch (Palm Down)",
+        "phase": "TAPER",
+        "notes": "Reset range pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Four-Point Rock Backs (Wrist Extension)",
+        "phase": "GPP",
+        "notes": "Open anterior wrist"
+      },
+      {
+        "name": "Massage Ball Wrist Sweep",
+        "phase": "GPP",
+        "notes": "Release fascia tension"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Four-Point Rock Backs (Wrist Extension)",
+        "phase": "TAPER",
+        "notes": "Maintain contact tolerance"
+      },
+      {
+        "name": "Massage Ball Wrist Sweep",
+        "phase": "TAPER",
+        "notes": "Short bursts for neural calm"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Contrast Wrist Baths",
+        "phase": "TAPER",
+        "notes": "Flush soreness and inflammation through temperature modulation"
+      },
+      {
+        "name": "Light Grip Iso Hold (Towel Squeeze)",
+        "phase": "TAPER",
+        "notes": "Maintain neuromuscular firing without joint load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pronation/Supination with Band",
+        "phase": "SPP",
+        "notes": "Controlled rotation under tension"
+      },
+      {
+        "name": "Grip Trainer \u2013 Soft Ball Pulse",
+        "phase": "SPP",
+        "notes": "Low-resistance endurance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pronation/Supination with Band",
+        "phase": "TAPER",
+        "notes": "Reduce amplitude, sharpen reflex"
+      },
+      {
+        "name": "Grip Trainer \u2013 Soft Ball Pulse",
+        "phase": "TAPER",
+        "notes": "CNS-friendly activation"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Reinforce capsule control"
+      },
+      {
+        "name": "Wrist Slides on Wall",
+        "phase": "GPP",
+        "notes": "Train straight-line control"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Add tempo to fluid motion"
+      },
+      {
+        "name": "Wrist Slides on Wall",
+        "phase": "SPP",
+        "notes": "Add band or incline"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Tactile Tapping (Finger to Wrist)",
+        "phase": "GPP",
+        "notes": "Desensitize contact zone"
+      },
+      {
+        "name": "Tactile Tapping (Finger to Wrist)",
+        "phase": "GPP",
+        "notes": "Progress with glove/impact layering"
+      },
+      {
+        "name": "Friction Roll with Tennis Ball",
+        "phase": "GPP",
+        "notes": "Mobilize tissue while reintroducing low-friction load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Distraction with Band",
+        "phase": "GPP",
+        "notes": "Open joint space"
+      },
+      {
+        "name": "Push-Up on Parallettes",
+        "phase": "GPP",
+        "notes": "Reduce wrist angle stress"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Distraction with Band",
+        "phase": "SPP",
+        "notes": "Load into new range"
+      },
+      {
+        "name": "Push-Up on Parallettes",
+        "phase": "SPP",
+        "notes": "Introduce compression tolerance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Weighted Carry (Wrist Supinated)",
+        "phase": "SPP",
+        "notes": "Stability under supinated load"
+      },
+      {
+        "name": "Wrist Rotation Iso Holds (Plate Hold)",
+        "phase": "SPP",
+        "notes": "Reinforce rotational stability"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Weighted Carry (Wrist Supinated)",
+        "phase": "TAPER",
+        "notes": "Maintain reflex control"
+      },
+      {
+        "name": "Wrist Rotation Iso Holds (Plate Hold)",
+        "phase": "TAPER",
+        "notes": "Short durations for CNS clarity"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Holds (Various Angles)",
+        "phase": "GPP",
+        "notes": "Build foundational load tolerance"
+      },
+      {
+        "name": "Plank to Palm Rockbacks",
+        "phase": "GPP",
+        "notes": "Joint loading in safe pattern"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Holds (Various Angles)",
+        "phase": "SPP",
+        "notes": "Expand angle range with resistance"
+      },
+      {
+        "name": "Plank to Palm Rockbacks",
+        "phase": "SPP",
+        "notes": "Introduce speed and range"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Band Extensions",
+        "phase": "GPP",
+        "notes": "Restore finger abduction strength"
+      },
+      {
+        "name": "Palm Squeeze with Soft Ball",
+        "phase": "GPP",
+        "notes": "Gentle reactivation"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Band Extensions",
+        "phase": "SPP",
+        "notes": "Increase reps and band tension"
+      },
+      {
+        "name": "Palm Squeeze with Soft Ball",
+        "phase": "SPP",
+        "notes": "Increase duration for deep tissue loading"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Flexor Isometric Press (Palm Down)",
+        "phase": "GPP",
+        "notes": "Controlled low-level force"
+      },
+      {
+        "name": "Finger Walks on Wall",
+        "phase": "GPP",
+        "notes": "Rebuild motor control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Flexor Isometric Press (Palm Down)",
+        "phase": "SPP",
+        "notes": "Add tension through loaded stretch"
+      },
+      {
+        "name": "Finger Walks on Wall",
+        "phase": "SPP",
+        "notes": "Increase ROM and vertical reach"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Flossing with Band",
+        "phase": "GPP",
+        "notes": "Mobilize connective tissue"
+      },
+      {
+        "name": "Manual Stretch (Wrist Extension + Finger Spread)",
+        "phase": "GPP",
+        "notes": "Release palmar tension"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger Flossing with Band",
+        "phase": "TAPER",
+        "notes": "Maintain glide without CNS drain"
+      },
+      {
+        "name": "Manual Stretch (Wrist Extension + Finger Spread)",
+        "phase": "TAPER",
+        "notes": "Maintain soft tissue readiness"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Contrast Bath (Warm \u2192 Cold)",
+        "phase": "GPP",
+        "notes": "Manage bruising and blood flow"
+      },
+      {
+        "name": "Gentle Grip Ball Squeeze",
+        "phase": "GPP",
+        "notes": "Reinforce soft contact tolerance"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "swelling",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist Elevation with Passive Opens",
+        "phase": "GPP",
+        "notes": "Drain fluid while restoring motion"
+      },
+      {
+        "name": "Open-Close Fists (Elevated)",
+        "phase": "GPP",
+        "notes": "Pump lymph manually"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wrist Elevation with Passive Opens",
+        "phase": "TAPER",
+        "notes": "Keep inflammation low under travel/fight prep"
+      },
+      {
+        "name": "Open-Close Fists (Elevated)",
+        "phase": "TAPER",
+        "notes": "Maintain circulation"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Finger Tip Drops Off Table",
+        "phase": "GPP",
+        "notes": "Rebuild tendon load"
+      },
+      {
+        "name": "Isometric Palm Press Against Wall",
+        "phase": "GPP",
+        "notes": "Build static load tolerance"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Finger Tip Drops Off Table",
+        "phase": "SPP",
+        "notes": "Add reps"
+      },
+      {
+        "name": "Isometric Palm Press Against Wall",
+        "phase": "SPP",
+        "notes": "Combine with ballistic grip"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eccentric Finger Tip Drops Off Table",
+        "phase": "TAPER",
+        "notes": "Maintain tissue health"
+      },
+      {
+        "name": "Isometric Palm Press Against Wall",
+        "phase": "TAPER",
+        "notes": "Light holds only"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pinch Plate Carry (Thick Plate)",
+        "phase": "SPP",
+        "notes": "Train grip control"
+      },
+      {
+        "name": "Finger Spread with Putty",
+        "phase": "SPP",
+        "notes": "Reinforce dynamic tension"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pinch Plate Carry (Thick Plate)",
+        "phase": "TAPER",
+        "notes": "Reduce load, increase hold precision"
+      },
+      {
+        "name": "Finger Spread with Putty",
+        "phase": "TAPER",
+        "notes": "Keep CNS low while maintaining skill"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Joint Glide Mobilization (Finger Pull)",
+        "phase": "GPP",
+        "notes": "Restore passive range"
+      },
+      {
+        "name": "Grip Reset with Banded Distraction",
+        "phase": "GPP",
+        "notes": "Reduce capsular block"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Joint Glide Mobilization (Finger Pull)",
+        "phase": "SPP",
+        "notes": "Add active ROM"
+      },
+      {
+        "name": "Grip Reset with Banded Distraction",
+        "phase": "SPP",
+        "notes": "Layer in isometric activation"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Tendon Gliding Series (Hook, Straight, Fist)",
+        "phase": "GPP",
+        "notes": "Free tendon sheaths"
+      },
+      {
+        "name": "Ball Rolling Under Palm",
+        "phase": "GPP",
+        "notes": "Stimulate fascia release"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Tendon Gliding Series (Hook, Straight, Fist)",
+        "phase": "SPP",
+        "notes": "Add volume and banded resistance"
+      },
+      {
+        "name": "Ball Rolling Under Palm",
+        "phase": "SPP",
+        "notes": "Control slow reps under pressure"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hand Iso Hold Around Grip Trainer",
+        "phase": "SPP",
+        "notes": "Low-motion tension"
+      },
+      {
+        "name": "Fingertip Holds on Wall",
+        "phase": "SPP",
+        "notes": "Stimulate contact point control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Hand Iso Hold Around Grip Trainer",
+        "phase": "TAPER",
+        "notes": "Retain isometric control with low CNS cost"
+      },
+      {
+        "name": "Fingertip Holds on Wall",
+        "phase": "TAPER",
+        "notes": "Taper down intensity, not precision"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Cold Ball Palm Roll",
+        "phase": "TAPER",
+        "notes": "Flush DOMS and reduce nerve tension"
+      },
+      {
+        "name": "Gentle Webbing Massage",
+        "phase": "TAPER",
+        "notes": "Reduce soft tissue fatigue in high-load weeks"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Pull-Back Holds (Isometric)",
+        "phase": "GPP",
+        "notes": "Restore extension control"
+      },
+      {
+        "name": "Wall Crawls (Backhand Contact)",
+        "phase": "GPP",
+        "notes": "Slow control in pain-free range"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Pull-Back Holds (Isometric)",
+        "phase": "SPP",
+        "notes": "Add reps and grip resistance"
+      },
+      {
+        "name": "Wall Crawls (Backhand Contact)",
+        "phase": "SPP",
+        "notes": "Layer return to punching function"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Finger Abduction",
+        "phase": "GPP",
+        "notes": "Isolate lateral joint activation"
+      },
+      {
+        "name": "Hook Grip Plate Pinches",
+        "phase": "GPP",
+        "notes": "Restore tendon-line coordination"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Finger Abduction",
+        "phase": "SPP",
+        "notes": "Increase resistance and range"
+      },
+      {
+        "name": "Hook Grip Plate Pinches",
+        "phase": "SPP",
+        "notes": "Progress to full ROM and fatigue"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Loaded Palm Extensions (Rubber Band)",
+        "phase": "GPP",
+        "notes": "Rebuild extensors safely"
+      },
+      {
+        "name": "Isometric Grip on Towel",
+        "phase": "GPP",
+        "notes": "Low-level tissue loading"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Loaded Palm Extensions (Rubber Band)",
+        "phase": "TAPER",
+        "notes": "Maintain high-rep tolerance"
+      },
+      {
+        "name": "Isometric Grip on Towel",
+        "phase": "TAPER",
+        "notes": "Sustain force capacity under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hand Wave Mobilization (Palm Up/Down)",
+        "phase": "GPP",
+        "notes": "Restore joint glide control"
+      },
+      {
+        "name": "Finger Fan-Outs on Table",
+        "phase": "GPP",
+        "notes": "Improve soft tissue glide"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hand Wave Mobilization (Palm Up/Down)",
+        "phase": "SPP",
+        "notes": "Progress to band-assisted flow"
+      },
+      {
+        "name": "Finger Fan-Outs on Table",
+        "phase": "SPP",
+        "notes": "Add tempo + finger spread control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Pull Finger Decompression",
+        "phase": "GPP",
+        "notes": "Reduce capsule compression"
+      },
+      {
+        "name": "Manual Metacarpal Glide (Therapist or Self)",
+        "phase": "GPP",
+        "notes": "Target precise joint blockages"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Pull Finger Decompression",
+        "phase": "SPP",
+        "notes": "Integrate active extension"
+      },
+      {
+        "name": "Manual Metacarpal Glide (Therapist or Self)",
+        "phase": "SPP",
+        "notes": "Reinforce with neuromuscular control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Fat Grip Farmer\u2019s Hold (Timed)",
+        "phase": "SPP",
+        "notes": "Develop crush grip stability"
+      },
+      {
+        "name": "Finger Squeeze Iso on Sandbag",
+        "phase": "SPP",
+        "notes": "Build variable surface control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Fat Grip Farmer\u2019s Hold (Timed)",
+        "phase": "TAPER",
+        "notes": "Drop load, maintain duration"
+      },
+      {
+        "name": "Finger Squeeze Iso on Sandbag",
+        "phase": "TAPER",
+        "notes": "Refine sharpness with light load"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Friction Ball Circles (Palm + Fingers)",
+        "phase": "GPP",
+        "notes": "Desensitize contact zones"
+      },
+      {
+        "name": "Hand Floss + Shake-Outs",
+        "phase": "GPP",
+        "notes": "Clear neural irritation"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Friction Ball Circles (Palm + Fingers)",
+        "phase": "SPP",
+        "notes": "Maintain mobility under neural tension"
+      },
+      {
+        "name": "Hand Floss + Shake-Outs",
+        "phase": "SPP",
+        "notes": "Maintain input through light reactive drills"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Gripper Iso Squeeze (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Load the tendon under control"
+      },
+      {
+        "name": "Elastic Band Finger Walks",
+        "phase": "SPP",
+        "notes": "Improve coordination under stress"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Gripper Iso Squeeze (Mid-Range)",
+        "phase": "TAPER",
+        "notes": "Cut volume, preserve tension"
+      },
+      {
+        "name": "Elastic Band Finger Walks",
+        "phase": "TAPER",
+        "notes": "Strip to patterning only"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ball Squeeze \u2192 Band Spread Pair",
+        "phase": "GPP",
+        "notes": "Rebuild both sides of grip chain"
+      },
+      {
+        "name": "Open-Close Grip Cycles with Metronome",
+        "phase": "GPP",
+        "notes": "Build neural rhythm"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Ball Squeeze \u2192 Band Spread Pair",
+        "phase": "TAPER",
+        "notes": "Alternate for balance + prep"
+      },
+      {
+        "name": "Open-Close Grip Cycles with Metronome",
+        "phase": "TAPER",
+        "notes": "Maintain readiness without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Band Expansions",
+        "phase": "GPP",
+        "notes": "Rebuild extensor activation"
+      },
+      {
+        "name": "Finger Taps on Hard Surface",
+        "phase": "GPP",
+        "notes": "Light impact reintroduction"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Band Expansions",
+        "phase": "SPP",
+        "notes": "Increase tension and hold duration"
+      },
+      {
+        "name": "Finger Taps on Hard Surface",
+        "phase": "SPP",
+        "notes": "Increase frequency to simulate grip release"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Rubber Band Finger Extensions",
+        "phase": "GPP",
+        "notes": "Strengthen extensors to rebalance tension"
+      },
+      {
+        "name": "Isometric Finger Pinch (Plate or Towel)",
+        "phase": "GPP",
+        "notes": "Load grip safely"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rubber Band Finger Extensions",
+        "phase": "SPP",
+        "notes": "Increase reps for contractile capacity"
+      },
+      {
+        "name": "Isometric Finger Pinch (Plate or Towel)",
+        "phase": "SPP",
+        "notes": "Add hold duration for endurance"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger CARs",
+        "phase": "GPP",
+        "notes": "Restore joint articulation"
+      },
+      {
+        "name": "Ball Squeeze with Pause",
+        "phase": "GPP",
+        "notes": "Encourage full ROM and control"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger CARs",
+        "phase": "TAPER",
+        "notes": "Maintain capsule glide pre-fight"
+      },
+      {
+        "name": "Ball Squeeze with Pause",
+        "phase": "TAPER",
+        "notes": "Add tempo holds without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Warm Water Finger Mobility",
+        "phase": "SPP",
+        "notes": "Loosen before drill"
+      },
+      {
+        "name": "Finger Slide Along Table Edge",
+        "phase": "SPP",
+        "notes": "Gentle full-range extension"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Warm Water Finger Mobility",
+        "phase": "TAPER",
+        "notes": "Use pre-fight as warm-up primer"
+      },
+      {
+        "name": "Finger Slide Along Table Edge",
+        "phase": "TAPER",
+        "notes": "Maintain motion with control"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Finger Traction",
+        "phase": "GPP",
+        "notes": "Reduce joint compression symptoms"
+      },
+      {
+        "name": "Tendon Glides (Straight\u2013Hook\u2013Fist)",
+        "phase": "GPP",
+        "notes": "Sequence finger movement"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Finger Traction",
+        "phase": "SPP",
+        "notes": "Add slow ROM reintegration"
+      },
+      {
+        "name": "Tendon Glides (Straight\u2013Hook\u2013Fist)",
+        "phase": "SPP",
+        "notes": "Speed up reps with precision"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Isometrics Against Resistance Band",
+        "phase": "SPP",
+        "notes": "Build tolerance in neutral grip"
+      },
+      {
+        "name": "Ice Massage Rolling (Small Ball)",
+        "phase": "SPP",
+        "notes": "Control inflammation post-training"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger Isometrics Against Resistance Band",
+        "phase": "TAPER",
+        "notes": "Maintain output with no irritation"
+      },
+      {
+        "name": "Ice Massage Rolling (Small Ball)",
+        "phase": "TAPER",
+        "notes": "Use as pre-session reset"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Finger Curls with Putty",
+        "phase": "GPP",
+        "notes": "Reset tendon load tolerance"
+      },
+      {
+        "name": "Isometric Grip on Soft Ball",
+        "phase": "GPP",
+        "notes": "Safely activate grip muscles"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Finger Curls with Putty",
+        "phase": "SPP",
+        "notes": "Build controlled eccentric strength"
+      },
+      {
+        "name": "Isometric Grip on Soft Ball",
+        "phase": "SPP",
+        "notes": "Extend holds under tension"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Finger Pumps",
+        "phase": "TAPER",
+        "notes": "Drain excess fluid"
+      },
+      {
+        "name": "Elevated Finger Pumps",
+        "phase": "TAPER",
+        "notes": "Repeat in between spar rounds"
+      },
+      {
+        "name": "Cold-Water Soak with Active Motion",
+        "phase": "TAPER",
+        "notes": "Reduce swelling while preserving dexterity"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Active Finger Flicks",
+        "phase": "TAPER",
+        "notes": "Flush light DOMS"
+      },
+      {
+        "name": "Active Finger Flicks",
+        "phase": "TAPER",
+        "notes": "Can pair with hand warm-up drills"
+      },
+      {
+        "name": "Mini Massage Gun Sweep (Finger Extensors)",
+        "phase": "TAPER",
+        "notes": "Reset tone post-padwork or grappling"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Partner Resistance Finger Push",
+        "phase": "GPP",
+        "notes": "Reinforce joint tracking"
+      },
+      {
+        "name": "TheraBand Finger Spider Press",
+        "phase": "GPP",
+        "notes": "Stimulate stabilizers"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Partner Resistance Finger Push",
+        "phase": "SPP",
+        "notes": "Add controlled chaos"
+      },
+      {
+        "name": "TheraBand Finger Spider Press",
+        "phase": "SPP",
+        "notes": "Progress to fatigue-endurance"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Gentle Finger Taps on Pad",
+        "phase": "GPP",
+        "notes": "Reintroduce contact with low impact"
+      },
+      {
+        "name": "Cold Ball Grip + Roll",
+        "phase": "GPP",
+        "notes": "Soothe tissue and maintain motion"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Flexed Finger Hold",
+        "phase": "GPP",
+        "notes": "Prevent excessive joint opening"
+      },
+      {
+        "name": "Flexor Stretch with Passive Assist",
+        "phase": "GPP",
+        "notes": "Restore balance"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Flexed Finger Hold",
+        "phase": "SPP",
+        "notes": "Load safely with grip tools"
+      },
+      {
+        "name": "Flexor Stretch with Passive Assist",
+        "phase": "SPP",
+        "notes": "Introduce loaded control"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Putty Squeeze Variations",
+        "phase": "GPP",
+        "notes": "Explore safe ROM"
+      },
+      {
+        "name": "Wrist + Finger Extension Combo",
+        "phase": "GPP",
+        "notes": "Restore chain mobility"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Putty Squeeze Variations",
+        "phase": "SPP",
+        "notes": "Build strength in all ranges"
+      },
+      {
+        "name": "Wrist + Finger Extension Combo",
+        "phase": "SPP",
+        "notes": "Transition to integrated drills"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Flossing (Rubber Band + Curl)",
+        "phase": "SPP",
+        "notes": "Mobilize soft tissue glide"
+      },
+      {
+        "name": "Open-Close Rapid Cycles",
+        "phase": "SPP",
+        "notes": "Sharpen neural speed"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger Flossing (Rubber Band + Curl)",
+        "phase": "TAPER",
+        "notes": "Light warmup integration"
+      },
+      {
+        "name": "Open-Close Rapid Cycles",
+        "phase": "TAPER",
+        "notes": "Light pulse drills before mitts"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Digit-Specific Flexion Holds (Putty or Band)",
+        "phase": "GPP",
+        "notes": "Isolate healing finger"
+      },
+      {
+        "name": "Elastic Finger Push-Press",
+        "phase": "GPP",
+        "notes": "Controlled activation"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Digit-Specific Flexion Holds (Putty or Band)",
+        "phase": "SPP",
+        "notes": "Add duration and compound grip"
+      },
+      {
+        "name": "Elastic Finger Push-Press",
+        "phase": "SPP",
+        "notes": "Increase push velocity"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Tape-Assisted Plyo Taps",
+        "phase": "SPP",
+        "notes": "Explosive but protected taps"
+      },
+      {
+        "name": "Mini Band Finger Spread-Hold",
+        "phase": "SPP",
+        "notes": "Stabilize joints under stretch"
+      }
+    ]
+  },
+  {
+    "location": "fingers",
+    "type": "sprain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Tape-Assisted Plyo Taps",
+        "phase": "TAPER",
+        "notes": "Transition to tap speed under load"
+      },
+      {
+        "name": "Mini Band Finger Spread-Hold",
+        "phase": "TAPER",
+        "notes": "Maintain control with low tension"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Neck Flexion (Wall)",
+        "phase": "GPP",
+        "notes": "Build static front-line control"
+      },
+      {
+        "name": "Neck Retraction with Band",
+        "phase": "GPP",
+        "notes": "Re-educate deep neck stabilizers"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Neck Flexion (Wall)",
+        "phase": "SPP",
+        "notes": "Increase duration or reps under fatigue"
+      },
+      {
+        "name": "Neck Retraction with Band",
+        "phase": "SPP",
+        "notes": "Layer resistance for endurance"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Neck Circles (Slow Tempo)",
+        "phase": "GPP",
+        "notes": "Restore capsule mobility"
+      },
+      {
+        "name": "Lacrosse Ball SCM Release",
+        "phase": "GPP",
+        "notes": "Break up fascial restriction"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Neck Circles (Slow Tempo)",
+        "phase": "TAPER",
+        "notes": "Maintain movement prep pre-fight"
+      },
+      {
+        "name": "Lacrosse Ball SCM Release",
+        "phase": "TAPER",
+        "notes": "Downregulate before comp"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neck CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Expand multi-directional range"
+      },
+      {
+        "name": "Partner-Assisted Neck Mobility",
+        "phase": "GPP",
+        "notes": "Restore safety in end ranges"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neck CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Integrate slow resistance patterns"
+      },
+      {
+        "name": "Partner-Assisted Neck Mobility",
+        "phase": "SPP",
+        "notes": "Add light resistance or timed holds"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall-Supported Neck Isometrics",
+        "phase": "SPP",
+        "notes": "Build low-risk tolerance"
+      },
+      {
+        "name": "Neck Extension with Towel Resistance",
+        "phase": "SPP",
+        "notes": "Develop concentric control"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall-Supported Neck Isometrics",
+        "phase": "TAPER",
+        "notes": "Retain tension pre-comp without fatigue"
+      },
+      {
+        "name": "Neck Extension with Towel Resistance",
+        "phase": "TAPER",
+        "notes": "Reduce load, maintain range"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Self-Massage (Traps & Cervical)",
+        "phase": "TAPER",
+        "notes": "Reduce postural overload and restore blood flow"
+      },
+      {
+        "name": "Gentle Neck Tilts (Assisted)",
+        "phase": "TAPER",
+        "notes": "Maintain low-stress mobility without stimulating CNS"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neck Glide with Chin Tucks",
+        "phase": "GPP",
+        "notes": "Clear anterior compression"
+      },
+      {
+        "name": "Quadruped Neck Extension",
+        "phase": "GPP",
+        "notes": "Explore range with body support"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neck Glide with Chin Tucks",
+        "phase": "SPP",
+        "notes": "Reinforce posture under load"
+      },
+      {
+        "name": "Quadruped Neck Extension",
+        "phase": "SPP",
+        "notes": "Add time under tension"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reactive Partner Pushes (Neck)",
+        "phase": "SPP",
+        "notes": "Train reactive stabilizers"
+      },
+      {
+        "name": "Neck Holds Against Swiss Ball (Wall)",
+        "phase": "SPP",
+        "notes": "Control unpredictable angles"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Reactive Partner Pushes (Neck)",
+        "phase": "TAPER",
+        "notes": "Short bursts for sharpness"
+      },
+      {
+        "name": "Neck Holds Against Swiss Ball (Wall)",
+        "phase": "TAPER",
+        "notes": "Deload while maintaining reflex"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger-Pad Circles on Affected Site",
+        "phase": "GPP",
+        "notes": "Restore contact tolerance"
+      },
+      {
+        "name": "Seated Weighted Shrugs",
+        "phase": "GPP",
+        "notes": "Light concentric reintroduction"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger-Pad Circles on Affected Site",
+        "phase": "SPP",
+        "notes": "Build tissue density and blood flow"
+      },
+      {
+        "name": "Seated Weighted Shrugs",
+        "phase": "SPP",
+        "notes": "Progress to tempo holds"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Neck Isometrics (4-Way)",
+        "phase": "GPP",
+        "notes": "Strengthen deep stabilizers in neutral"
+      },
+      {
+        "name": "Neck Stability on Stability Ball",
+        "phase": "GPP",
+        "notes": "Introduce reactive challenge"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Neck Isometrics (4-Way)",
+        "phase": "SPP",
+        "notes": "Add band variability for dynamic tension"
+      },
+      {
+        "name": "Neck Stability on Stability Ball",
+        "phase": "SPP",
+        "notes": "Add longer duration with reps"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Chin Retraction Holds",
+        "phase": "GPP",
+        "notes": "Prevent repeated extension strain"
+      },
+      {
+        "name": "Prone Neck Lifts (Nose Hover)",
+        "phase": "GPP",
+        "notes": "Start unloaded in controlled range"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chin Retraction Holds",
+        "phase": "SPP",
+        "notes": "Add hold duration with band assistance"
+      },
+      {
+        "name": "Prone Neck Lifts (Nose Hover)",
+        "phase": "SPP",
+        "notes": "Add reps or band tension"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "swelling",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Elevated Neck Drainage Positioning",
+        "phase": "GPP",
+        "notes": "Passive drain setup"
+      },
+      {
+        "name": "Neck Massage with Ball (Cervical Line)",
+        "phase": "GPP",
+        "notes": "Stimulate lymphatic flow"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Elevated Neck Drainage Positioning",
+        "phase": "TAPER",
+        "notes": "Combine with light tilts to reduce fluid"
+      },
+      {
+        "name": "Neck Massage with Ball (Cervical Line)",
+        "phase": "TAPER",
+        "notes": "Maintain fluid clearance"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neck Eccentric Nods (Band)",
+        "phase": "GPP",
+        "notes": "Rebuild load tolerance"
+      },
+      {
+        "name": "Manual Resistance Lateral Flexion",
+        "phase": "GPP",
+        "notes": "Activate with external guidance"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neck Eccentric Nods (Band)",
+        "phase": "SPP",
+        "notes": "Increase tempo + reps"
+      },
+      {
+        "name": "Manual Resistance Lateral Flexion",
+        "phase": "SPP",
+        "notes": "Add self-resistance"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neck Eccentric Nods (Band)",
+        "phase": "TAPER",
+        "notes": "Sustain with low tension"
+      },
+      {
+        "name": "Manual Resistance Lateral Flexion",
+        "phase": "TAPER",
+        "notes": "Reduce volume"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Multi-Plane Neck Holds",
+        "phase": "GPP",
+        "notes": "Rebuild 3D positional strength"
+      },
+      {
+        "name": "Scap-Neck Coordination Drill",
+        "phase": "GPP",
+        "notes": "Reinforce cervical-scapular link"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Multi-Plane Neck Holds",
+        "phase": "SPP",
+        "notes": "Add reps or tempo"
+      },
+      {
+        "name": "Scap-Neck Coordination Drill",
+        "phase": "SPP",
+        "notes": "Add load"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Multi-Plane Neck Holds",
+        "phase": "TAPER",
+        "notes": "Maintain sharpness"
+      },
+      {
+        "name": "Scap-Neck Coordination Drill",
+        "phase": "TAPER",
+        "notes": "Keep coordination cues"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine Band-Resisted Neck Flexion",
+        "phase": "SPP",
+        "notes": "Strengthen anterior chain with load"
+      },
+      {
+        "name": "Neck Clock Isometrics",
+        "phase": "SPP",
+        "notes": "Hit multiple vectors under control"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Supine Band-Resisted Neck Flexion",
+        "phase": "TAPER",
+        "notes": "Reduce tension to maintain activation"
+      },
+      {
+        "name": "Neck Clock Isometrics",
+        "phase": "TAPER",
+        "notes": "Shorten sets for freshness"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Gentle Neck Side Tilts (Passive Stretch)",
+        "phase": "TAPER",
+        "notes": "Restore lateral mobility with zero CNS cost"
+      },
+      {
+        "name": "Trap Bar Hang & Neck Relaxation",
+        "phase": "TAPER",
+        "notes": "Passive lengthening of cervical chain under light traction"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slide Chin Glide",
+        "phase": "SPP",
+        "notes": "Restore alignment mid-load"
+      },
+      {
+        "name": "TheraBand Diagonal Pulls",
+        "phase": "SPP",
+        "notes": "Controlled joint motion in arc"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "impingement",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Wall Slide Chin Glide",
+        "phase": "TAPER",
+        "notes": "Maintain neck posture pre-fight"
+      },
+      {
+        "name": "TheraBand Diagonal Pulls",
+        "phase": "TAPER",
+        "notes": "Flush motion without overactivation"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neck Towel Oscillation Drill",
+        "phase": "GPP",
+        "notes": "Promote blood flow safely"
+      },
+      {
+        "name": "Gentle Isometric Hold (Forehead Press)",
+        "phase": "GPP",
+        "notes": "Initiate low-grade motor unit work"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neck Towel Oscillation Drill",
+        "phase": "TAPER",
+        "notes": "Use as flush in taper days"
+      },
+      {
+        "name": "Gentle Isometric Hold (Forehead Press)",
+        "phase": "TAPER",
+        "notes": "Retain activation for posture"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Jaw Clench (Mouthguard In)",
+        "phase": "GPP",
+        "notes": "Restore isometric bite control"
+      },
+      {
+        "name": "Lateral Jaw Pushes (Finger Resistance)",
+        "phase": "GPP",
+        "notes": "Reinforce lateral jaw control"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Jaw Clench (Mouthguard In)",
+        "phase": "SPP",
+        "notes": "Simulate pressure during clinch/guard scenarios"
+      },
+      {
+        "name": "Lateral Jaw Pushes (Finger Resistance)",
+        "phase": "SPP",
+        "notes": "Add tempo for resilience under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "TMJ Release (Massage Ball Under Cheekbone)",
+        "phase": "GPP",
+        "notes": "Break up muscular tension and trigger points"
+      },
+      {
+        "name": "Open-Close Control Drill (Slow Tempo)",
+        "phase": "GPP",
+        "notes": "Retrain smooth TMJ motion"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "TMJ Release (Massage Ball Under Cheekbone)",
+        "phase": "TAPER",
+        "notes": "Maintain jaw relaxation before high-pressure sessions"
+      },
+      {
+        "name": "Open-Close Control Drill (Slow Tempo)",
+        "phase": "TAPER",
+        "notes": "Use for cooldown neuromuscular reset"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Jaw Taps (Knuckle Percussion)",
+        "phase": "SPP",
+        "notes": "Desensitize superficial jaw pain"
+      },
+      {
+        "name": "Mouthguard Clench Holds (Short Bursts)",
+        "phase": "SPP",
+        "notes": "Simulate real-fight biting effort"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Jaw Taps (Knuckle Percussion)",
+        "phase": "TAPER",
+        "notes": "Maintain contact tolerance during deload"
+      },
+      {
+        "name": "Mouthguard Clench Holds (Short Bursts)",
+        "phase": "TAPER",
+        "notes": "Sharpen reflex under CNS constraint"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Jaw Circles (Controlled Articulation)",
+        "phase": "TAPER",
+        "notes": "Restore capsule glide and reduce DOMS post-spar"
+      },
+      {
+        "name": "Soft Tissue Sweep (Massage Gun \u2013 Mandible Line)",
+        "phase": "TAPER",
+        "notes": "Clear inflammation from high-contact areas without overstim"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Jaw Glide with Tongue Stabilization",
+        "phase": "GPP",
+        "notes": "Unlock joint restriction via tongue-brain coordination"
+      },
+      {
+        "name": "Isometric Front Bite (Stick or Towel Hold)",
+        "phase": "GPP",
+        "notes": "Train anterior bite engagement"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Jaw Glide with Tongue Stabilization",
+        "phase": "SPP",
+        "notes": "Reinforce movement path under light resistance"
+      },
+      {
+        "name": "Isometric Front Bite (Stick or Towel Hold)",
+        "phase": "SPP",
+        "notes": "Sustain isometric endurance for clinch defense"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side-to-Side Jaw Slide (Resisted)",
+        "phase": "SPP",
+        "notes": "Train control across mandible path"
+      },
+      {
+        "name": "Chin Strap Isometric Pull",
+        "phase": "SPP",
+        "notes": "Build jaw positioning control against force"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "instability",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Side-to-Side Jaw Slide (Resisted)",
+        "phase": "TAPER",
+        "notes": "Preserve smooth tracking at low tension"
+      },
+      {
+        "name": "Chin Strap Isometric Pull",
+        "phase": "TAPER",
+        "notes": "Use light tension for neuromuscular readiness"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Cold Jaw Glide with Finger Guide",
+        "phase": "TAPER",
+        "notes": "Reduce inflammation through cold-assisted tracking"
+      },
+      {
+        "name": "Gentle Manual Drainage (Lymph Sweep Down Jawline)",
+        "phase": "TAPER",
+        "notes": "Clear residual fluid and minimize puffiness pre-fight"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cheek Tap Drill (Fingertip Percussion)",
+        "phase": "GPP",
+        "notes": "Gradual reintroduction to contact"
+      },
+      {
+        "name": "Soft Jaw Holds (Finger Placement Support)",
+        "phase": "GPP",
+        "notes": "Restore muscular tone without stress"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cheek Tap Drill (Fingertip Percussion)",
+        "phase": "SPP",
+        "notes": "Normalize pressure for future striking"
+      },
+      {
+        "name": "Soft Jaw Holds (Finger Placement Support)",
+        "phase": "SPP",
+        "notes": "Add duration for structural reconditioning"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Passive Jaw Drops (Guided with Hand)",
+        "phase": "GPP",
+        "notes": "Restore range into opening"
+      },
+      {
+        "name": "Mirror-Controlled Chewing Motion Drill",
+        "phase": "GPP",
+        "notes": "Reinforce symmetrical control"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Passive Jaw Drops (Guided with Hand)",
+        "phase": "SPP",
+        "notes": "Build slow eccentric return control"
+      },
+      {
+        "name": "Mirror-Controlled Chewing Motion Drill",
+        "phase": "SPP",
+        "notes": "Apply in guard scenarios with tension"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Lateral Bite (Tongue Depressor)",
+        "phase": "GPP",
+        "notes": "Load tendon path with low strain"
+      },
+      {
+        "name": "TMJ Pulse Drill (5s Squeeze / 5s Relax)",
+        "phase": "GPP",
+        "notes": "Cycle tension/rest for tendon health"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Lateral Bite (Tongue Depressor)",
+        "phase": "SPP",
+        "notes": "Progress to resisted isometrics"
+      },
+      {
+        "name": "TMJ Pulse Drill (5s Squeeze / 5s Relax)",
+        "phase": "SPP",
+        "notes": "Sharpen bite readiness"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "tendonitis",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Lateral Bite (Tongue Depressor)",
+        "phase": "TAPER",
+        "notes": "Light pre-fight activation"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Tongue-to-Palate Hold",
+        "phase": "GPP",
+        "notes": "Reset jaw-head-cervical coordination"
+      },
+      {
+        "name": "Soft Jaw Stretch with Finger Under Chin",
+        "phase": "GPP",
+        "notes": "Gentle open with support"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Tongue-to-Palate Hold",
+        "phase": "TAPER",
+        "notes": "Prime neuromuscular path pre-competition"
+      },
+      {
+        "name": "Soft Jaw Stretch with Finger Under Chin",
+        "phase": "TAPER",
+        "notes": "Maintain glide and tone"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Resisted Jaw Opening with Band",
+        "phase": "SPP",
+        "notes": "Stimulate joint capsule with control"
+      },
+      {
+        "name": "Side Clench Isometrics (Mouthguard)",
+        "phase": "SPP",
+        "notes": "Emulate off-angle pressure during sparring"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "sprain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Resisted Jaw Opening with Band",
+        "phase": "TAPER",
+        "notes": "Reduce band tension for low-load groove work"
+      },
+      {
+        "name": "Side Clench Isometrics (Mouthguard)",
+        "phase": "TAPER",
+        "notes": "Short bursts for CNS reset"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Guided Jaw Clench with Chin Support",
+        "phase": "GPP",
+        "notes": "Rebuild jaw line control after overstretch"
+      },
+      {
+        "name": "Isometric Front Pull (Towel Grip)",
+        "phase": "GPP",
+        "notes": "Train anterior resistance safely"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Guided Jaw Clench with Chin Support",
+        "phase": "SPP",
+        "notes": "Apply time-under-tension method"
+      },
+      {
+        "name": "Isometric Front Pull (Towel Grip)",
+        "phase": "SPP",
+        "notes": "Increase duration and complexity"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Open-Hold-Release Protocol",
+        "phase": "SPP",
+        "notes": "Challenge end-range with hold"
+      },
+      {
+        "name": "Tongue Circle Control (Against Palate)",
+        "phase": "SPP",
+        "notes": "Guide mandible path with tongue pressure"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Open-Hold-Release Protocol",
+        "phase": "TAPER",
+        "notes": "Reduce effort, maintain pattern"
+      },
+      {
+        "name": "Tongue Circle Control (Against Palate)",
+        "phase": "TAPER",
+        "notes": "Maintain control while minimizing fatigue"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Manual Jaw Glide (Clinician Support Sim)",
+        "phase": "TAPER",
+        "notes": "Promote mobility and pain-free control for final prep"
+      },
+      {
+        "name": "Ice + Vibration Combo (Massage Wand)",
+        "phase": "TAPER",
+        "notes": "Calm surface tissue while reducing delayed soreness"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Near-Far Focal Shifts",
+        "phase": "GPP",
+        "notes": "Reset accommodative strain"
+      },
+      {
+        "name": "Pencil Push-Ups",
+        "phase": "GPP",
+        "notes": "Reinforce convergence"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Near-Far Focal Shifts",
+        "phase": "SPP",
+        "notes": "Integrate rapid gaze transitions during movement"
+      },
+      {
+        "name": "Pencil Push-Ups",
+        "phase": "SPP",
+        "notes": "Add dynamic movement to sharpen reflex"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eye Circles (Clockwise & Counter)",
+        "phase": "GPP",
+        "notes": "Restore extraocular mobility"
+      },
+      {
+        "name": "Palming + Breath Reset",
+        "phase": "GPP",
+        "notes": "Downregulate eye tension"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "tightness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eye Circles (Clockwise & Counter)",
+        "phase": "TAPER",
+        "notes": "Maintain smooth gaze range under low arousal"
+      },
+      {
+        "name": "Palming + Breath Reset",
+        "phase": "TAPER",
+        "notes": "Use as parasympathetic reset post-spar"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Saccadic Eye Jumps (Horizontal/Vertical)",
+        "phase": "SPP",
+        "notes": "Rebuild rapid gaze redirection with intent"
+      },
+      {
+        "name": "Blink Tolerance Training",
+        "phase": "SPP",
+        "notes": "Condition discomfort threshold"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Saccadic Eye Jumps (Horizontal/Vertical)",
+        "phase": "TAPER",
+        "notes": "Reduce rep count for light CNS prep"
+      },
+      {
+        "name": "Blink Tolerance Training",
+        "phase": "TAPER",
+        "notes": "Integrate fast flinch control"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cool Compress (Post-Contact)",
+        "phase": "GPP",
+        "notes": "Reduce superficial orbital tension post-strike"
+      },
+      {
+        "name": "Visual Meditation (Gaze Anchor)",
+        "phase": "GPP",
+        "notes": "Reset focus and pressure via visual stillness"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Head-Eye Coordination Drills",
+        "phase": "GPP",
+        "notes": "Stabilize gaze during neck movement"
+      },
+      {
+        "name": "Laser Pointer Target Tracing",
+        "phase": "GPP",
+        "notes": "Track controlled paths"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Head-Eye Coordination Drills",
+        "phase": "SPP",
+        "notes": "Progress to reactive direction changes"
+      },
+      {
+        "name": "Laser Pointer Target Tracing",
+        "phase": "SPP",
+        "notes": "Add irregular movement under duress"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Gentle Orbital Massage (Around Socket)",
+        "phase": "GPP",
+        "notes": "Restore tissue mobility post-impact"
+      },
+      {
+        "name": "Tactile Reflex Training (Hand Sways)",
+        "phase": "GPP",
+        "notes": "Reinforce blink reflex and tracking"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Gentle Orbital Massage (Around Socket)",
+        "phase": "SPP",
+        "notes": "Rebuild pressure tolerance under shadow boxing"
+      },
+      {
+        "name": "Tactile Reflex Training (Hand Sways)",
+        "phase": "SPP",
+        "notes": "Pair with head movement for striking simulation"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eye Tracking: Figure 8 Pattern",
+        "phase": "GPP",
+        "notes": "Improve orbital fluidity"
+      },
+      {
+        "name": "360\u00b0 Gaze Anchor Drill",
+        "phase": "GPP",
+        "notes": "Expand peripheral control"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Eye Tracking: Figure 8 Pattern",
+        "phase": "TAPER",
+        "notes": "Use as low-CNS warmup"
+      },
+      {
+        "name": "360\u00b0 Gaze Anchor Drill",
+        "phase": "TAPER",
+        "notes": "Maintain range without visual strain"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reaction Ball Catch (Unpredictable Bounce)",
+        "phase": "SPP",
+        "notes": "Train rapid eye-hand response"
+      },
+      {
+        "name": "Light Board Tracking (e.g. FitLight)",
+        "phase": "SPP",
+        "notes": "Optimize reaction time"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Reaction Ball Catch (Unpredictable Bounce)",
+        "phase": "TAPER",
+        "notes": "Keep CNS alert under low volume"
+      },
+      {
+        "name": "Light Board Tracking (e.g. FitLight)",
+        "phase": "TAPER",
+        "notes": "Sharpen visual reflex before competition"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Ball Drop Reaction Catch",
+        "phase": "SPP",
+        "notes": "Train instant visual-motor sync"
+      },
+      {
+        "name": "Partner Flash Cue (Coloured Gloves)",
+        "phase": "SPP",
+        "notes": "React to color-coded hand triggers"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Ball Drop Reaction Catch",
+        "phase": "TAPER",
+        "notes": "Reduce volume, emphasize reflex sharpness"
+      },
+      {
+        "name": "Partner Flash Cue (Coloured Gloves)",
+        "phase": "TAPER",
+        "notes": "Refine accuracy under cognitive load"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Laser Pointer Rapid Switch (Left\u2013Right\u2013Center)",
+        "phase": "GPP",
+        "notes": "Restore speed without load"
+      },
+      {
+        "name": "Peripheral Light Tap Drill",
+        "phase": "GPP",
+        "notes": "Boost visual span awareness"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Laser Pointer Rapid Switch (Left\u2013Right\u2013Center)",
+        "phase": "SPP",
+        "notes": "Layer in head movement and light footwork"
+      },
+      {
+        "name": "Peripheral Light Tap Drill",
+        "phase": "SPP",
+        "notes": "React to lateral cues with limb coordination"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "FitLight Reflex Matrix",
+        "phase": "SPP",
+        "notes": "Develop rapid gaze-fix-react sequencing"
+      },
+      {
+        "name": "Multi-Task Gaze + Balance",
+        "phase": "SPP",
+        "notes": "Combine unstable surface with gaze shifting"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "strain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "FitLight Reflex Matrix",
+        "phase": "TAPER",
+        "notes": "Use short bursts to spike CNS sharpness"
+      },
+      {
+        "name": "Multi-Task Gaze + Balance",
+        "phase": "TAPER",
+        "notes": "Downscale duration, maintain complexity"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Vertical Ball Toss with Gaze Lock",
+        "phase": "GPP",
+        "notes": "Train stable vertical gaze during dynamic movement"
+      },
+      {
+        "name": "Colored Cue Shadow Boxing",
+        "phase": "GPP",
+        "notes": "React to visual stimulus with motor response"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Vertical Ball Toss with Gaze Lock",
+        "phase": "SPP",
+        "notes": "Progress to split-focus dual-task"
+      },
+      {
+        "name": "Colored Cue Shadow Boxing",
+        "phase": "SPP",
+        "notes": "Execute selective combinations per cue"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Facial Ice Massage (Circular Motion)",
+        "phase": "GPP",
+        "notes": "Reduce initial trauma response"
+      },
+      {
+        "name": "Soft Ball Pressure Roll (Zygomatic Area)",
+        "phase": "GPP",
+        "notes": "Restore pressure tolerance"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Facial Ice Massage (Circular Motion)",
+        "phase": "SPP",
+        "notes": "Local desensitization for glove recontact"
+      },
+      {
+        "name": "Soft Ball Pressure Roll (Zygomatic Area)",
+        "phase": "SPP",
+        "notes": "Mobilize soft tissue around cheekbone"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "swelling",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lymphatic Drainage Sweep (Jaw to Temple)",
+        "phase": "GPP",
+        "notes": "Promote drainage and facial decompression"
+      },
+      {
+        "name": "Cold Compression Wrap (Full Face)",
+        "phase": "GPP",
+        "notes": "Reduce acute swelling"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Lymphatic Drainage Sweep (Jaw to Temple)",
+        "phase": "TAPER",
+        "notes": "Keep fluid balance pre-weigh-in"
+      },
+      {
+        "name": "Cold Compression Wrap (Full Face)",
+        "phase": "TAPER",
+        "notes": "Flush inflammation without nervous system drag"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Low-Frequency TENS (Infraorbital Region)",
+        "phase": "SPP",
+        "notes": "Dull local sensitivity"
+      },
+      {
+        "name": "Facial Percussion Taps (Forehead, Cheeks)",
+        "phase": "SPP",
+        "notes": "Normalize contact sensation"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "pain",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Low-Frequency TENS (Infraorbital Region)",
+        "phase": "TAPER",
+        "notes": "Retain contact tolerance before competition"
+      },
+      {
+        "name": "Facial Percussion Taps (Forehead, Cheeks)",
+        "phase": "TAPER",
+        "notes": "Final prep for glove impact"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Manual Facial Tension Release (Temporalis)",
+        "phase": "GPP",
+        "notes": "Release global face tension"
+      },
+      {
+        "name": "Jaw-to-Face Gentle Pulses",
+        "phase": "GPP",
+        "notes": "Reset jaw-to-face tension chain"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Manual Facial Tension Release (Temporalis)",
+        "phase": "TAPER",
+        "notes": "Keep relaxation pre-fight"
+      },
+      {
+        "name": "Jaw-to-Face Gentle Pulses",
+        "phase": "TAPER",
+        "notes": "Downregulate threat reflex"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Facial Yoga \u2013 Cheek Lift Holds",
+        "phase": "GPP",
+        "notes": "Restore motor control and mobility"
+      },
+      {
+        "name": "Diagonal Facial Slide (Forehead to Jaw)",
+        "phase": "GPP",
+        "notes": "Break up tension planes"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Facial Yoga \u2013 Cheek Lift Holds",
+        "phase": "SPP",
+        "notes": "Add duration or jaw load"
+      },
+      {
+        "name": "Diagonal Facial Slide (Forehead to Jaw)",
+        "phase": "SPP",
+        "notes": "Integrate with neck rotation"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cold Spoon Press (Under Eye / Cheek)",
+        "phase": "GPP",
+        "notes": "Calm capillary bruising"
+      },
+      {
+        "name": "Facial Tap Drill with Fingers",
+        "phase": "GPP",
+        "notes": "Reduce sensory threat response"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cold Spoon Press (Under Eye / Cheek)",
+        "phase": "SPP",
+        "notes": "Adapt to mask pressure during sparring"
+      },
+      {
+        "name": "Facial Tap Drill with Fingers",
+        "phase": "SPP",
+        "notes": "Normalize glove-pressure contact"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Neuro-Fascial Release \u2013 Zygomatic Pull",
+        "phase": "GPP",
+        "notes": "Restore glide of facial fascia"
+      },
+      {
+        "name": "Ball Glide Under Zygomatic Arch",
+        "phase": "GPP",
+        "notes": "Mobilize trapped fascial pathways"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Neuro-Fascial Release \u2013 Zygomatic Pull",
+        "phase": "SPP",
+        "notes": "Integrate with neck and jaw control"
+      },
+      {
+        "name": "Ball Glide Under Zygomatic Arch",
+        "phase": "SPP",
+        "notes": "Relieve contact-triggered restrictions"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Facial CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Re-engage multi-directional facial motor control"
+      },
+      {
+        "name": "Resistance Band Jaw-Pull + Facial Hold",
+        "phase": "GPP",
+        "notes": "Activate jaw-to-face chain"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "stiffness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Facial CARs (Controlled Articular Rotations)",
+        "phase": "TAPER",
+        "notes": "Sharpen awareness pre-fight"
+      },
+      {
+        "name": "Resistance Band Jaw-Pull + Facial Hold",
+        "phase": "TAPER",
+        "notes": "Integrate under light spar stress"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Topical Desensitization Tap + Hold",
+        "phase": "GPP",
+        "notes": "Reduce nociceptive sensitivity"
+      },
+      {
+        "name": "Trigger Point Press (TMJ and Cheekbone)",
+        "phase": "GPP",
+        "notes": "Release referred facial tension"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Topical Desensitization Tap + Hold",
+        "phase": "SPP",
+        "notes": "Sustain pressure threshold during glove drills"
+      },
+      {
+        "name": "Trigger Point Press (TMJ and Cheekbone)",
+        "phase": "SPP",
+        "notes": "Combine with head movement patterns"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "swelling",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Facial Gua Sha Scrape (Jaw to Orbital)",
+        "phase": "SPP",
+        "notes": "Promote fluid clearance with contour"
+      },
+      {
+        "name": "Alternating Ice + Heat (Face Wraps)",
+        "phase": "SPP",
+        "notes": "Stimulate circulation and reset nerves"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "swelling",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Facial Gua Sha Scrape (Jaw to Orbital)",
+        "phase": "TAPER",
+        "notes": "Flush pre-fight congestion"
+      },
+      {
+        "name": "Alternating Ice + Heat (Face Wraps)",
+        "phase": "TAPER",
+        "notes": "Prevent chronic inflammation"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Stability Drill \u2013 Head Shake + Facial Iso",
+        "phase": "GPP",
+        "notes": "Lock face/jaw position under perturbation"
+      },
+      {
+        "name": "Resistance Band Pull \u2013 Face to Neck Anchors",
+        "phase": "GPP",
+        "notes": "Rebuild kinetic link"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Stability Drill \u2013 Head Shake + Facial Iso",
+        "phase": "SPP",
+        "notes": "Pair with slip bag or spar flinch"
+      },
+      {
+        "name": "Resistance Band Pull \u2013 Face to Neck Anchors",
+        "phase": "SPP",
+        "notes": "Tie to reactive defense cues"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Face-Focused Box Breathing",
+        "phase": "GPP",
+        "notes": "Downregulate facial tone"
+      },
+      {
+        "name": "Facial Stretch Flow (Eyes Closed Guided)",
+        "phase": "GPP",
+        "notes": "Reset face and breath links"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "soreness",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Face-Focused Box Breathing",
+        "phase": "TAPER",
+        "notes": "Anchor parasympathetic state pre-fight"
+      },
+      {
+        "name": "Facial Stretch Flow (Eyes Closed Guided)",
+        "phase": "TAPER",
+        "notes": "Prime CNS clarity"
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "strain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "General Isometric Holds (5-position circuit)",
+        "phase": "GPP",
+        "notes": "Engage large muscle groups without load; avoid pain. Hold 15\u201330s x 3 rounds."
+      },
+      {
+        "name": "Foam Rolling + Tempo Eccentrics",
+        "phase": "GPP",
+        "notes": "Roll full body + slow eccentrics to recondition tissue under control."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "strain",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "sprain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Joint Stability Circuit (ankle, knee, wrist)",
+        "phase": "GPP",
+        "notes": "Use bands, BOSU, or unstable surfaces. Controlled tempo x 3 sets."
+      },
+      {
+        "name": "Isometric Joint Compression Holds",
+        "phase": "GPP",
+        "notes": "Mid-range holds for joint stiffness without movement. Build neuromuscular confidence."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "sprain",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Global Mobility Flow (Full Body)",
+        "phase": "GPP",
+        "notes": "12\u201315 mins of dynamic stretching, PNF holds, and breath-led movement."
+      },
+      {
+        "name": "Contrast Showers + Deep Tissue Tooling",
+        "phase": "GPP",
+        "notes": "1 min hot / 1 min cold x5 + lacrosse ball on most restricted areas."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Recovery Circuit (Airdyne, Row, Band Mobility)",
+        "phase": "GPP",
+        "notes": "Low RPE movement with mobility and breath pacing. 3\u20134 rounds."
+      },
+      {
+        "name": "Epsom Salt Bath + Active ROM Post-Soak",
+        "phase": "GPP",
+        "notes": "20 mins hot soak + unloaded movement to promote circulation and recovery."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "soreness",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Pain-Free Loading (Top/Bottom Range)",
+        "phase": "GPP",
+        "notes": "Isometric tension at pain-free end ranges, hold 30s. 3\u20134 sets daily."
+      },
+      {
+        "name": "Slow Tempo Eccentrics on Major Lifts",
+        "phase": "GPP",
+        "notes": "3\u20134s lowering phase. Reinforces tendon capacity. Start unloaded."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Breathwork + Parasympathetic Ground Flow",
+        "phase": "GPP",
+        "notes": "Releases tension. 4s inhale / 8s exhale, paired with gentle mobility."
+      },
+      {
+        "name": "Neuro-Friendly Band Activation",
+        "phase": "GPP",
+        "notes": "Band retraction, extension, rotation drills. 3 sets light resistance."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Loaded CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Strengthen joint control. 3 reps per direction, per joint."
+      },
+      {
+        "name": "Breath-Guided Dynamic Stretch Flow",
+        "phase": "GPP",
+        "notes": "Mobility tied to exhale. Repeat sequence x3 rounds full body."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Active Range Isometrics (Antagonist Focus)",
+        "phase": "GPP",
+        "notes": "Contract opposing muscles near end range to protect joint integrity."
+      },
+      {
+        "name": "Proprioceptive Loading on Sliders or Bands",
+        "phase": "GPP",
+        "notes": "Adds joint awareness while avoiding terminal ROM."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "tightness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Global Foam Roll + PNF Stretch (target problem area)",
+        "phase": "GPP",
+        "notes": "Start with 60\u201390s foam roll across main tension zones, then add 3x15s PNF contract-relax sets."
+      },
+      {
+        "name": "Full-Body Mobility Circuit",
+        "phase": "GPP",
+        "notes": "Include inchworms, world\u2019s greatest stretch, deep lunge opens. 2\u20133 rounds."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tightness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Global Foam Roll + PNF Stretch (target problem area)",
+        "phase": "SPP",
+        "notes": "progress to dynamic end-range mobility drills (e.g. CARS, banded openers)."
+      },
+      {
+        "name": "Full-Body Mobility Circuit",
+        "phase": "SPP",
+        "notes": "add mild loaded mobility (e.g. goblet squat hold, elevated Cossack stretch)."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Holds (target tendon path)",
+        "phase": "GPP",
+        "notes": "5x45s holds at mid-range (e.g. Spanish squat, wall sit, mid-dip hold) depending on limb."
+      },
+      {
+        "name": "Banded Flossing + Elevation",
+        "phase": "GPP",
+        "notes": "Wrap a light compression band around joint/muscle belly, move through ROM for 30s bouts."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Holds (target tendon path)",
+        "phase": "SPP",
+        "notes": "progress to slow eccentrics (e.g. heel drops, tempo pushups)."
+      },
+      {
+        "name": "Banded Flossing + Elevation",
+        "phase": "SPP",
+        "notes": "drop band, add slow ROM + high bloodflow pump work."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Stability Holds on Unstable Surface",
+        "phase": "GPP",
+        "notes": "Hold split stance, tall plank, or single leg positions on foam pad or BOSU. 3x20\u201330s."
+      },
+      {
+        "name": "Banded Stability Reps",
+        "phase": "GPP",
+        "notes": "Use bands to pull joint into slight instability during slow reps (e.g. banded wall squats)."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Stability Holds on Unstable Surface",
+        "phase": "SPP",
+        "notes": "Add light perturbation (e.g. partner taps, ball tosses)."
+      },
+      {
+        "name": "Banded Stability Reps",
+        "phase": "SPP",
+        "notes": "progress to reactive reps or light load with control."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Heavy Slow Resistance Protocol",
+        "phase": "GPP",
+        "notes": "3x8\u201310 slow tempo reps (e.g. 3-0-3) for target tendon line. Emphasize full control."
+      },
+      {
+        "name": "Contrast Therapy + Active ROM",
+        "phase": "GPP",
+        "notes": "Ice/heat alternated 3\u20135x per area, then slow joint circles or band ROM drills."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Heavy Slow Resistance Protocol",
+        "phase": "SPP",
+        "notes": "shift to sport-mimicking movement patterns under tempo."
+      },
+      {
+        "name": "Contrast Therapy + Active ROM",
+        "phase": "SPP",
+        "notes": "remove passive input, use self-mobilizing drills only."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Active Range Expansion with Isometrics",
+        "phase": "GPP",
+        "notes": "Contract-relax against resistance (e.g. doorway press, glute bridge hold). 3x20s."
+      },
+      {
+        "name": "Loaded Mobility Toolwork",
+        "phase": "GPP",
+        "notes": "Massage gun or lacrosse ball across the stuck tissue pre-movement."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Active Range Expansion with Isometrics",
+        "phase": "SPP",
+        "notes": "build into controlled eccentrics or flowing mobility reps."
+      },
+      {
+        "name": "Loaded Mobility Toolwork",
+        "phase": "SPP",
+        "notes": "replace with movement-based mobility under low load."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Elevation + Compression (10\u201315 min post)",
+        "phase": "GPP",
+        "notes": "Advise athlete to elevate the area above heart and wrap with compression sleeve."
+      },
+      {
+        "name": "Low Tension Mobility & Lymph Flow",
+        "phase": "GPP",
+        "notes": "Air squats, light swings, or open chain movement to keep blood moving without stress."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Elevation + Compression (10\u201315 min post)",
+        "phase": "SPP",
+        "notes": "remove if bruising fades, switch to pump/flush circuits."
+      },
+      {
+        "name": "Low Tension Mobility & Lymph Flow",
+        "phase": "SPP",
+        "notes": "increase ROM and tempo gradually as pain subsides."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Joint-Specific Controlled Eccentrics",
+        "phase": "GPP",
+        "notes": "Apply slow lowering to regain ROM (e.g. leg lowers, tempo dips, etc). 3x6 reps."
+      },
+      {
+        "name": "Wrap Support + ROM Reset",
+        "phase": "GPP",
+        "notes": "Use elastic wrap during movement if needed. Add unloaded full-ROM circles pre-training."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Joint-Specific Controlled Eccentrics",
+        "phase": "SPP",
+        "notes": "layer in anti-extension isometrics (e.g. plank drag)."
+      },
+      {
+        "name": "Wrap Support + ROM Reset",
+        "phase": "SPP",
+        "notes": "taper wrap use unless re-aggravation risk is present."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "soreness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Light Aerobic Flow + Stretch",
+        "phase": "GPP",
+        "notes": "5\u201310 mins of cyclical movement (e.g. bike, jog) into a 3-round mobility flow."
+      },
+      {
+        "name": "Epsom Salt Soak or Contrast Shower",
+        "phase": "GPP",
+        "notes": "Passive recovery aid to flush DOMS. 15\u201320 mins soak or 5 cycles of hot/cold shower."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "soreness",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Light Aerobic Flow + Stretch",
+        "phase": "SPP",
+        "notes": "taper flow to 1\u20132 rounds and reduce aerobic duration if recovery improves."
+      },
+      {
+        "name": "Epsom Salt Soak or Contrast Shower",
+        "phase": "SPP",
+        "notes": "reserve for high soreness or poor sleep."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "pain",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Breath-Guided Joint Mobilization",
+        "phase": "GPP",
+        "notes": "Focus on 3\u20134 joint circles or controlled articulations paired with slow nasal breathing."
+      },
+      {
+        "name": "Elevate + Wrap Protocol",
+        "phase": "GPP",
+        "notes": "Advise light compression wrap and elevation above heart for 10\u201315 min post-training."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "pain",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Breath-Guided Joint Mobilization",
+        "phase": "SPP",
+        "notes": "convert to low-load tempo exercises for the affected region."
+      },
+      {
+        "name": "Elevate + Wrap Protocol",
+        "phase": "SPP",
+        "notes": "if pain subsides, begin reintroducing low RPE movement."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "contusion",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Soft Tissue Flushing (Foam Roller or Ball)",
+        "phase": "GPP",
+        "notes": "Target surrounding areas without pressing directly on the bruise. Aids lymphatic drainage."
+      },
+      {
+        "name": "Elevated Leg or Arm Pulses",
+        "phase": "GPP",
+        "notes": "Lie down and elevate the bruised limb. Perform light flexion/extension to improve circulation and reduce pooling."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "contusion",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "swelling",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Compression Wrap with Mobility Flow",
+        "phase": "GPP",
+        "notes": "Apply compression bandage, then perform gentle mobility drills to reduce swelling without provoking flare-up."
+      },
+      {
+        "name": "Limb Elevation + Isometric Squeeze",
+        "phase": "GPP",
+        "notes": "Elevate the limb above heart level. Perform light squeezes or quad/glute sets to stimulate fluid return."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "swelling",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Slow Eccentric Resistance with Band",
+        "phase": "GPP",
+        "notes": "Controlled lengthening under band tension to stimulate tendon healing without overload."
+      },
+      {
+        "name": "Isometric Holds at Pain-Free Angle",
+        "phase": "GPP",
+        "notes": "Hold static contractions near the range of irritation to reinforce tendon capacity and reduce pain sensitivity."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "tendonitis",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "impingement",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Controlled Joint CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Move through safe ranges under tension. Avoid painful arcs, build capsule space."
+      },
+      {
+        "name": "Banded Joint Distraction (Light Tension)",
+        "phase": "GPP",
+        "notes": "Use light band tension to open joint space while moving through low-load range of motion."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "impingement",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "instability",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Reactive Stability Drills (Eyes Closed or Band Perturbation)",
+        "phase": "GPP",
+        "notes": "Use bands or unstable surfaces to challenge joint control and proprioception under minimal load."
+      },
+      {
+        "name": "Isometric Holds with Joint Alignment Cueing",
+        "phase": "GPP",
+        "notes": "Reinforce motor control and safe joint positions through static holds in vulnerable ranges."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "instability",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Active Mobility Circuits (Full Body or Region-Specific)",
+        "phase": "GPP",
+        "notes": "Mobilize through dynamic movement. Emphasize rhythmic motion, not static stretching."
+      },
+      {
+        "name": "Heat-then-Move Protocol (e.g., Hot Pack + Flow)",
+        "phase": "GPP",
+        "notes": "Apply localized heat for 10 min, then transition into controlled movement or CARs to expand usable range."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "stiffness",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Joint Guarding Isometrics",
+        "phase": "GPP",
+        "notes": "Hold positions just short of lockout to train tissue safety and reinforce control at terminal ranges."
+      },
+      {
+        "name": "Partial ROM Strength Drills (Reverse Range)",
+        "phase": "GPP",
+        "notes": "Train in shortened range away from end-range stretch. Focus on deceleration and reverse control."
+      }
+    ]
+  },
+  {
+    "location": "unspecified",
+    "type": "hyperextension",
+    "phase_progression": "SPP",
+    "drills": []
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Double-Leg Eccentric Heel Raises (3s Lower)",
+        "phase": "GPP",
+        "notes": "Build tendon resilience"
+      },
+      {
+        "name": "Isometric Heel Hold (Knee Extended)",
+        "phase": "GPP",
+        "notes": "30s holds at mid-range"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Eccentric Heel Raises (3s Lower)",
+        "phase": "SPP",
+        "notes": "Progress to single-leg or add weight"
+      },
+      {
+        "name": "Isometric Heel Hold (Knee Extended)",
+        "phase": "SPP",
+        "notes": "Increase angle difficulty (stair edge)"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "GPP",
+        "notes": "Improve proprioception"
+      },
+      {
+        "name": "Banded Ankle Dorsiflexion Mobilization",
+        "phase": "GPP",
+        "notes": "Restore ankle ROM"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "SPP",
+        "notes": "Add catch/throw perturbations"
+      },
+      {
+        "name": "Banded Ankle Dorsiflexion Mobilization",
+        "phase": "SPP",
+        "notes": "Integrate into calf stretch position"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Calf Isometric Press (5s Holds)",
+        "phase": "GPP",
+        "notes": "Pain-modulating tension"
+      },
+      {
+        "name": "Walking Ankle ROM Drills (Heel-Toe Rolls)",
+        "phase": "GPP",
+        "notes": "Dynamic mobility"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Calf Isometric Press (5s Holds)",
+        "phase": "TAPER",
+        "notes": "Reduce hold duration pre-comp"
+      },
+      {
+        "name": "Walking Ankle ROM Drills (Heel-Toe Rolls)",
+        "phase": "TAPER",
+        "notes": "Use as warmup primer"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Bent-Knee Heel Drops",
+        "phase": "GPP",
+        "notes": "Target soleus"
+      },
+      {
+        "name": "Unilateral Pogo Hops (Low Amplitude)",
+        "phase": "GPP",
+        "notes": "Reintroduce elasticity"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Bent-Knee Heel Drops",
+        "phase": "SPP",
+        "notes": "Add rotation (internal/external hip bias)"
+      },
+      {
+        "name": "Unilateral Pogo Hops (Low Amplitude)",
+        "phase": "SPP",
+        "notes": "Increase height/speed"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Isometric Holds)",
+        "phase": "TAPER",
+        "notes": "Maintain intrinsic foot strength without load"
+      },
+      {
+        "name": "Night Splint-Assisted Calf Stretch",
+        "phase": "TAPER",
+        "notes": "Passive ROM maintenance during sleep cycles"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Heel Drop Over Edge (Knee Bent)",
+        "phase": "GPP",
+        "notes": "Soleus-targeted tension"
+      },
+      {
+        "name": "Unilateral Eccentric Step-Overs (3s Lower)",
+        "phase": "GPP",
+        "notes": "Functional deceleration"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Heel Drop Over Edge (Knee Bent)",
+        "phase": "SPP",
+        "notes": "Add weight vest + rotation challenge"
+      },
+      {
+        "name": "Unilateral Eccentric Step-Overs (3s Lower)",
+        "phase": "SPP",
+        "notes": "Increase step height + speed"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Stretch with Isometric Activation",
+        "phase": "GPP",
+        "notes": "Combine passive ROM + active tension"
+      },
+      {
+        "name": "Seated Ankle Alphabet (Weighted)",
+        "phase": "GPP",
+        "notes": "Improve arthrokinematics"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Towel Stretch with Isometric Activation",
+        "phase": "TAPER",
+        "notes": "Reduce hold duration"
+      },
+      {
+        "name": "Seated Ankle Alphabet (Weighted)",
+        "phase": "TAPER",
+        "notes": "Lighten resistance, focus on control"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bilateral Pogo Jumps \u2192 Unilateral Transition",
+        "phase": "GPP",
+        "notes": "Rebuild elastic capacity"
+      },
+      {
+        "name": "Downhill Walking Eccentrics",
+        "phase": "GPP",
+        "notes": "Controlled loading"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bilateral Pogo Jumps \u2192 Unilateral Transition",
+        "phase": "SPP",
+        "notes": "Progress to directional hops"
+      },
+      {
+        "name": "Downhill Walking Eccentrics",
+        "phase": "SPP",
+        "notes": "Increase grade/speed"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Night-Time Compression Sleeve + Dorsiflexion",
+        "phase": "TAPER",
+        "notes": "Maintain vascular flow + ROM during sleep"
+      },
+      {
+        "name": "Isometric Toe Presses Against Wall",
+        "phase": "TAPER",
+        "notes": "5s holds to prime neural drive pre-competition"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Heel Raise with Tibial Rotation",
+        "phase": "GPP",
+        "notes": "3D control"
+      },
+      {
+        "name": "Foam Roller Calf Flossing (Band-Assisted)",
+        "phase": "GPP",
+        "notes": "Improve sliding surfaces"
+      }
+    ]
+  },
+  {
+    "location": "achilles",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Heel Raise with Tibial Rotation",
+        "phase": "SPP",
+        "notes": "Add unstable surface (balance pad)"
+      },
+      {
+        "name": "Foam Roller Calf Flossing (Band-Assisted)",
+        "phase": "SPP",
+        "notes": "Pre-activity mobilization"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Isometric Heel Holds (30s)",
+        "phase": "GPP",
+        "notes": "Pain modulation"
+      },
+      {
+        "name": "Eccentric Inversion Walks (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Strengthen medial chain"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Isometric Heel Holds (30s)",
+        "phase": "SPP",
+        "notes": "Add unstable surface (foam pad)"
+      },
+      {
+        "name": "Eccentric Inversion Walks (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Add resistance band"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Weighted Dorsiflexion Mobilization (Knee Over Toe)",
+        "phase": "GPP",
+        "notes": "Improve closed-chain ROM"
+      },
+      {
+        "name": "Unilateral Alphabet Tracing (Toe Writing)",
+        "phase": "GPP",
+        "notes": "Restore fine motor control"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Weighted Dorsiflexion Mobilization (Knee Over Toe)",
+        "phase": "SPP",
+        "notes": "Add lateral movement component"
+      },
+      {
+        "name": "Unilateral Alphabet Tracing (Toe Writing)",
+        "phase": "SPP",
+        "notes": "Progress to dynamic patterns"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Eversion-Isometric Hold (10s On/Off)",
+        "phase": "GPP",
+        "notes": "Peroneal activation"
+      },
+      {
+        "name": "Seated Calf Isometric Press (Wall Resistance)",
+        "phase": "GPP",
+        "notes": "Load without movement"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Eversion-Isometric Hold (10s On/Off)",
+        "phase": "TAPER",
+        "notes": "Reduce volume, maintain tension"
+      },
+      {
+        "name": "Seated Calf Isometric Press (Wall Resistance)",
+        "phase": "TAPER",
+        "notes": "Short-duration holds"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Walks (3-5s Lower)",
+        "phase": "GPP",
+        "notes": "Tibialis anterior focus"
+      },
+      {
+        "name": "Single-Leg Clock Reaches (12-Point)",
+        "phase": "GPP",
+        "notes": "Dynamic stability"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Walks (3-5s Lower)",
+        "phase": "SPP",
+        "notes": "Add incline surface"
+      },
+      {
+        "name": "Single-Leg Clock Reaches (12-Point)",
+        "phase": "SPP",
+        "notes": "Add catch/throw component"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Plantarflexion Hold (Wall Lean)",
+        "phase": "GPP",
+        "notes": "45s holds"
+      },
+      {
+        "name": "Lateral Mini-Band Shuffles (Partial Squat)",
+        "phase": "GPP",
+        "notes": "Glute-ankle coupling"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Plantarflexion Hold (Wall Lean)",
+        "phase": "SPP",
+        "notes": "Add single-leg pulses"
+      },
+      {
+        "name": "Lateral Mini-Band Shuffles (Partial Squat)",
+        "phase": "SPP",
+        "notes": "Add directional changes"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Tibial Rotation Mobilization (Band-Assisted)",
+        "phase": "GPP",
+        "notes": "Improve joint play"
+      },
+      {
+        "name": "Single-Leg Eccentric Step Downs (3s Lower)",
+        "phase": "GPP",
+        "notes": "Control deceleration"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Tibial Rotation Mobilization (Band-Assisted)",
+        "phase": "SPP",
+        "notes": "Integrate with squat patterns"
+      },
+      {
+        "name": "Single-Leg Eccentric Step Downs (3s Lower)",
+        "phase": "SPP",
+        "notes": "Add rotational component"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ankle CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Maintain full ROM"
+      },
+      {
+        "name": "Low-Load Calf Pump BFR (30-15-15-15)",
+        "phase": "GPP",
+        "notes": "Stimulate tissue remodeling"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Ankle CARs (Controlled Articular Rotations)",
+        "phase": "TAPER",
+        "notes": "Daily mobility primer"
+      },
+      {
+        "name": "Low-Load Calf Pump BFR (30-15-15-15)",
+        "phase": "TAPER",
+        "notes": "Reduce to 1x/week"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Night Splint-Assisted Dorsiflexion Stretch",
+        "phase": "TAPER",
+        "notes": "Passive ROM maintenance during sleep"
+      },
+      {
+        "name": "Isometric Ankle Lock Holds (Pre-Activation)",
+        "phase": "TAPER",
+        "notes": "10s holds before competition drills"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Unilateral Pogo Hops (Submaximal Height)",
+        "phase": "GPP",
+        "notes": "Rebuild elasticity"
+      },
+      {
+        "name": "Eccentric Plantarflexion Walks (Heel-Toe)",
+        "phase": "GPP",
+        "notes": "Control foot strike"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Unilateral Pogo Hops (Submaximal Height)",
+        "phase": "SPP",
+        "notes": "Increase directional variance"
+      },
+      {
+        "name": "Eccentric Plantarflexion Walks (Heel-Toe)",
+        "phase": "SPP",
+        "notes": "Progress to uneven terrain"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Distraction Mobilization",
+        "phase": "GPP",
+        "notes": "Reduce joint stiffness"
+      },
+      {
+        "name": "Single-Leg Balance with Eyes Closed",
+        "phase": "GPP",
+        "notes": "Challenge proprioception"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Distraction Mobilization",
+        "phase": "SPP",
+        "notes": "Pair with dynamic movements"
+      },
+      {
+        "name": "Single-Leg Balance with Eyes Closed",
+        "phase": "SPP",
+        "notes": "Add head turns"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Isometric Toe Curls)",
+        "phase": "GPP",
+        "notes": "Intrinsic foot strength"
+      },
+      {
+        "name": "Marble Pickups with Toes",
+        "phase": "GPP",
+        "notes": "Fine motor control"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Isometric Toe Curls)",
+        "phase": "TAPER",
+        "notes": "Reduce volume"
+      },
+      {
+        "name": "Marble Pickups with Toes",
+        "phase": "TAPER",
+        "notes": "Maintenance only"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun - Peroneal Sweep (30s)",
+        "phase": "TAPER",
+        "notes": "Reduce stiffness pre-competition"
+      },
+      {
+        "name": "Dynamic Calf Stretch with Tibial Rotation",
+        "phase": "TAPER",
+        "notes": "Active ROM before events"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lateral Bound to Stick Landing",
+        "phase": "GPP",
+        "notes": "Eccentric control"
+      },
+      {
+        "name": "Single-Leg Heel Raise with Knee Bend",
+        "phase": "GPP",
+        "notes": "Soleus focus"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Lateral Bound to Stick Landing",
+        "phase": "SPP",
+        "notes": "Increase distance/speed"
+      },
+      {
+        "name": "Single-Leg Heel Raise with Knee Bend",
+        "phase": "SPP",
+        "notes": "Add weight vest"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ankle Rocker Board Circles",
+        "phase": "GPP",
+        "notes": "Multiplanar stability"
+      },
+      {
+        "name": "Eccentric Toe Drags (Posterior Chain)",
+        "phase": "GPP",
+        "notes": "Hamstring-ankle coupling"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Ankle Rocker Board Circles",
+        "phase": "SPP",
+        "notes": "Add resistance"
+      },
+      {
+        "name": "Eccentric Toe Drags (Posterior Chain)",
+        "phase": "SPP",
+        "notes": "Add sled drag"
+      }
+    ]
+  },
+  {
+    "location": "ankle",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Ice Cup Ankle Circumduction",
+        "phase": "TAPER",
+        "notes": "Pain modulation + ROM (acute flare-ups)"
+      },
+      {
+        "name": "Compression Sleeve + Ankle CARs",
+        "phase": "TAPER",
+        "notes": "Maintain mobility under compression"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Towel Curl Hold (90\u00b0 Flexion)",
+        "phase": "GPP",
+        "notes": "Pain modulation"
+      },
+      {
+        "name": "Eccentric Band Curl (3s Lower)",
+        "phase": "GPP",
+        "notes": "Tendon reloading"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Towel Curl Hold (90\u00b0 Flexion)",
+        "phase": "SPP",
+        "notes": "Add shoulder abduction"
+      },
+      {
+        "name": "Eccentric Band Curl (3s Lower)",
+        "phase": "SPP",
+        "notes": "Increase band resistance"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Unilateral Hammer Curl (Pronated Grip)",
+        "phase": "GPP",
+        "notes": "Address asymmetries"
+      },
+      {
+        "name": "Supination ROM with Dowel",
+        "phase": "GPP",
+        "notes": "Restore rotation"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Unilateral Hammer Curl (Pronated Grip)",
+        "phase": "SPP",
+        "notes": "Add rotational finish"
+      },
+      {
+        "name": "Supination ROM with Dowel",
+        "phase": "SPP",
+        "notes": "Load with mini-band"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Chin-Up Hold (90\u00b0)",
+        "phase": "GPP",
+        "notes": "Functional angle carryover"
+      },
+      {
+        "name": "Wall Slide Bicep CARs",
+        "phase": "GPP",
+        "notes": "Maintain full ROM"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Isometric Chin-Up Hold (90\u00b0)",
+        "phase": "TAPER",
+        "notes": "Reduce hold time"
+      },
+      {
+        "name": "Wall Slide Bicep CARs",
+        "phase": "TAPER",
+        "notes": "Active recovery use"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Rope Curl (3-5s Lower)",
+        "phase": "GPP",
+        "notes": "Brachialis focus"
+      },
+      {
+        "name": "Single-Arm Cable Isometric Hold (Mid-Range)",
+        "phase": "GPP",
+        "notes": "Time under tension"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Rope Curl (3-5s Lower)",
+        "phase": "SPP",
+        "notes": "Add unstable stance"
+      },
+      {
+        "name": "Single-Arm Cable Isometric Hold (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Integrate step/lunge"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Prone Incline Curl (Slow Eccentric)",
+        "phase": "GPP",
+        "notes": "Isolate long head"
+      },
+      {
+        "name": "Banded Bicep Stretch with Pronation",
+        "phase": "GPP",
+        "notes": "Improve extensibility"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Prone Incline Curl (Slow Eccentric)",
+        "phase": "SPP",
+        "notes": "Add tempo variations"
+      },
+      {
+        "name": "Banded Bicep Stretch with Pronation",
+        "phase": "SPP",
+        "notes": "Pair with concentric work"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Unilateral Zottman Curl",
+        "phase": "GPP",
+        "notes": "Eccentric overload"
+      },
+      {
+        "name": "Isometric Door Frame Hold (Flexed Elbow)",
+        "phase": "GPP",
+        "notes": "Home-accessible"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Unilateral Zottman Curl",
+        "phase": "SPP",
+        "notes": "Increase supination speed"
+      },
+      {
+        "name": "Isometric Door Frame Hold (Flexed Elbow)",
+        "phase": "SPP",
+        "notes": "Add shoulder internal rotation"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "BFR Bicep Curl (30-15-15-15)",
+        "phase": "GPP",
+        "notes": "Low-load remodeling"
+      },
+      {
+        "name": "Dynamic Bicep Stretch with Band",
+        "phase": "GPP",
+        "notes": "Active mobility"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "BFR Bicep Curl (30-15-15-15)",
+        "phase": "TAPER",
+        "notes": "Reduce to 1x/week"
+      },
+      {
+        "name": "Dynamic Bicep Stretch with Band",
+        "phase": "TAPER",
+        "notes": "Pre-competition primer"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Massage Gun - Distal Bicep Tendon Glide",
+        "phase": "TAPER",
+        "notes": "Reduce stiffness pre-event"
+      },
+      {
+        "name": "Isometric Flexion Against Wall (10s On/Off)",
+        "phase": "TAPER",
+        "notes": "Neuromuscular priming"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Chin-Up Lowering (3s)",
+        "phase": "GPP",
+        "notes": "Compound movement focus"
+      },
+      {
+        "name": "Unilateral Cable Rotation Curl",
+        "phase": "GPP",
+        "notes": "Rotational control"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Chin-Up Lowering (3s)",
+        "phase": "SPP",
+        "notes": "Add weight vest"
+      },
+      {
+        "name": "Unilateral Cable Rotation Curl",
+        "phase": "SPP",
+        "notes": "Increase cable angle"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Isometric Bicep Hold (Overhead)",
+        "phase": "GPP",
+        "notes": "End-range strength"
+      },
+      {
+        "name": "Banded Bicep CARs (Continuous Motion)",
+        "phase": "GPP",
+        "notes": "Joint mobility"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Isometric Bicep Hold (Overhead)",
+        "phase": "SPP",
+        "notes": "Add shoulder flexion"
+      },
+      {
+        "name": "Banded Bicep CARs (Continuous Motion)",
+        "phase": "SPP",
+        "notes": "Loaded carryover"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Resisted Curl (Isometric Mid-Range)",
+        "phase": "GPP",
+        "notes": "No equipment needed"
+      },
+      {
+        "name": "Supine Bicep Stretch with Pronation",
+        "phase": "GPP",
+        "notes": "Passive ROM"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Towel Resisted Curl (Isometric Mid-Range)",
+        "phase": "TAPER",
+        "notes": "Reduce intensity"
+      },
+      {
+        "name": "Supine Bicep Stretch with Pronation",
+        "phase": "TAPER",
+        "notes": "Maintenance only"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Compression Sleeve + Active Flexion",
+        "phase": "TAPER",
+        "notes": "Maintain circulation under compression"
+      },
+      {
+        "name": "Ice Cup Tendon Glides (Acute Flare-Ups)",
+        "phase": "TAPER",
+        "notes": "Pain modulation post-training"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Unilateral Reverse Curl Eccentric (3s Lower)",
+        "phase": "GPP",
+        "notes": "Brachioradialis focus"
+      },
+      {
+        "name": "Isometric Rope Clutch Hold",
+        "phase": "GPP",
+        "notes": "Grip-bicep integration"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Unilateral Reverse Curl Eccentric (3s Lower)",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      },
+      {
+        "name": "Isometric Rope Clutch Hold",
+        "phase": "SPP",
+        "notes": "Add body sway"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Prone Suspension Trainer Curl (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "Core-bicep coupling"
+      },
+      {
+        "name": "Wall-Assisted Bicep Lengthening",
+        "phase": "GPP",
+        "notes": "Controlled eccentric overload"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Prone Suspension Trainer Curl (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Increase incline"
+      },
+      {
+        "name": "Wall-Assisted Bicep Lengthening",
+        "phase": "SPP",
+        "notes": "Add pulse"
+      }
+    ]
+  },
+  {
+    "location": "bicep",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Vibration Plate Bicep Flush (30s On/Off)",
+        "phase": "TAPER",
+        "notes": "Enhance recovery between bouts"
+      },
+      {
+        "name": "Dynamic Twisting Towel Wring",
+        "phase": "TAPER",
+        "notes": "Maintain supination/pronation control"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Double-Leg Eccentric Calf Raise (4s Lower)",
+        "phase": "GPP",
+        "notes": "Tendon reloading"
+      },
+      {
+        "name": "Isometric Calf Hold (Straight Knee)",
+        "phase": "GPP",
+        "notes": "30s holds at peak contraction"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Eccentric Calf Raise (4s Lower)",
+        "phase": "SPP",
+        "notes": "Progress to single-leg"
+      },
+      {
+        "name": "Isometric Calf Hold (Straight Knee)",
+        "phase": "SPP",
+        "notes": "Add external load"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bent-Knee Calf Raise (Soleus Focus)",
+        "phase": "GPP",
+        "notes": "Isolate soleus"
+      },
+      {
+        "name": "Single-Leg Balance on BOSU Ball",
+        "phase": "GPP",
+        "notes": "Ankle proprioception"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bent-Knee Calf Raise (Soleus Focus)",
+        "phase": "SPP",
+        "notes": "Add tempo (2-up, 4-down)"
+      },
+      {
+        "name": "Single-Leg Balance on BOSU Ball",
+        "phase": "SPP",
+        "notes": "Add catch/throw"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Calf Isometric Press (5s On/Off)",
+        "phase": "GPP",
+        "notes": "Pain modulation"
+      },
+      {
+        "name": "Foam Roller Calf Sweeps",
+        "phase": "GPP",
+        "notes": "Tissue mobilization"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Seated Calf Isometric Press (5s On/Off)",
+        "phase": "TAPER",
+        "notes": "Reduce to maintenance volume"
+      },
+      {
+        "name": "Foam Roller Calf Sweeps",
+        "phase": "TAPER",
+        "notes": "Pre-competition flush"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Jump Rope (Low Amplitude)",
+        "phase": "GPP",
+        "notes": "Reintroduce elasticity"
+      },
+      {
+        "name": "Single-Leg Heel Walk (Anterior Tib Focus)",
+        "phase": "GPP",
+        "notes": "Address antagonist weakness"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Jump Rope (Low Amplitude)",
+        "phase": "SPP",
+        "notes": "Increase height/speed"
+      },
+      {
+        "name": "Single-Leg Heel Walk (Anterior Tib Focus)",
+        "phase": "SPP",
+        "notes": "Add incline"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Plantarflexion (Slow Release)",
+        "phase": "GPP",
+        "notes": "Control end-range"
+      },
+      {
+        "name": "Single-Leg Calf Raise Off Step (Full ROM)",
+        "phase": "GPP",
+        "notes": "Strengthen stretched position"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Ankle Plantarflexion (Slow Release)",
+        "phase": "SPP",
+        "notes": "Add pulses at peak"
+      },
+      {
+        "name": "Single-Leg Calf Raise Off Step (Full ROM)",
+        "phase": "SPP",
+        "notes": "Add weight vest"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Pogo Hops (Submaximal Effort)",
+        "phase": "GPP",
+        "notes": "Rebuild spring stiffness"
+      },
+      {
+        "name": "Isometric Toe Press (Wall Resistance)",
+        "phase": "GPP",
+        "notes": "45s holds"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pogo Hops (Submaximal Effort)",
+        "phase": "SPP",
+        "notes": "Add lateral component"
+      },
+      {
+        "name": "Isometric Toe Press (Wall Resistance)",
+        "phase": "SPP",
+        "notes": "Integrate into lunge position"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Night Splint-Assisted Calf Stretch",
+        "phase": "GPP",
+        "notes": "Passive ROM"
+      },
+      {
+        "name": "Massage Gun - Gastrocnemius Cross-Fiber",
+        "phase": "GPP",
+        "notes": "Release knots"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Night Splint-Assisted Calf Stretch",
+        "phase": "TAPER",
+        "notes": "Wear 2-4 hours pre-competition"
+      },
+      {
+        "name": "Massage Gun - Gastrocnemius Cross-Fiber",
+        "phase": "TAPER",
+        "notes": "30s pre-activation"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Compression Sleeve + Ankle Pumps",
+        "phase": "TAPER",
+        "notes": "Maintain circulation without load"
+      },
+      {
+        "name": "Low-Load BFR Calf Raises (20% 1RM)",
+        "phase": "TAPER",
+        "notes": "High-rep metabolic stimulus (15-15-15)"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Raise with Rotation",
+        "phase": "GPP",
+        "notes": "Multiplanar control"
+      },
+      {
+        "name": "Single-Leg Balance with Eyes Closed",
+        "phase": "GPP",
+        "notes": "Challenge proprioception"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Calf Raise with Rotation",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "Single-Leg Balance with Eyes Closed",
+        "phase": "SPP",
+        "notes": "Add head turns"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Tibialis Anterior Isometric Hold (Toe Lift)",
+        "phase": "GPP",
+        "notes": "Antagonist activation"
+      },
+      {
+        "name": "Depth Drop to Calf Raise (6-inch Box)",
+        "phase": "GPP",
+        "notes": "Eccentric absorption"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Tibialis Anterior Isometric Hold (Toe Lift)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      },
+      {
+        "name": "Depth Drop to Calf Raise (6-inch Box)",
+        "phase": "SPP",
+        "notes": "Increase height"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dynamic Calf Stretch with Tibial Rotation",
+        "phase": "GPP",
+        "notes": "Active mobility"
+      },
+      {
+        "name": "Marble Pickups with Toes",
+        "phase": "GPP",
+        "notes": "Intrinsic foot strength"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Dynamic Calf Stretch with Tibial Rotation",
+        "phase": "TAPER",
+        "notes": "Pre-competition primer"
+      },
+      {
+        "name": "Marble Pickups with Toes",
+        "phase": "TAPER",
+        "notes": "Maintenance only"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Ice Cup Gastrocnemius Stroking",
+        "phase": "TAPER",
+        "notes": "Pain modulation for acute flare-ups"
+      },
+      {
+        "name": "Isometric Heel Tap Holds (Pre-Activation)",
+        "phase": "TAPER",
+        "notes": "10s holds before explosive movements"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sled Push with Toe Focus",
+        "phase": "GPP",
+        "notes": "Build concentric power"
+      },
+      {
+        "name": "Single-Leg Eccentric Step Downs (Calf Emphasis)",
+        "phase": "GPP",
+        "notes": "Control deceleration"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Sled Push with Toe Focus",
+        "phase": "SPP",
+        "notes": "Increase load/speed"
+      },
+      {
+        "name": "Single-Leg Eccentric Step Downs (Calf Emphasis)",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Soleus Mobilization (Seated)",
+        "phase": "GPP",
+        "notes": "Improve ankle dorsiflexion"
+      },
+      {
+        "name": "Unilateral Pogo Hops (Linear \u2192 Lateral)",
+        "phase": "GPP",
+        "notes": "Rebuild elasticity"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Soleus Mobilization (Seated)",
+        "phase": "SPP",
+        "notes": "Integrate into squat"
+      },
+      {
+        "name": "Unilateral Pogo Hops (Linear \u2192 Lateral)",
+        "phase": "SPP",
+        "notes": "Sport-specific directions"
+      }
+    ]
+  },
+  {
+    "location": "calf",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Towel Stretch with Isometric Hold",
+        "phase": "TAPER",
+        "notes": "Passive-Active ROM combo"
+      },
+      {
+        "name": "Vibrating Foam Roller Flush",
+        "phase": "TAPER",
+        "notes": "Reduce tone pre-competition (2x30s)"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug Isometric Hold (90/90 Position)",
+        "phase": "GPP",
+        "notes": "Maintain rib-pelvis alignment"
+      },
+      {
+        "name": "Pallof Press Isometric (Kneeling)",
+        "phase": "GPP",
+        "notes": "20s holds"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug Isometric Hold (90/90 Position)",
+        "phase": "SPP",
+        "notes": "Add band resistance to limbs"
+      },
+      {
+        "name": "Pallof Press Isometric (Kneeling)",
+        "phase": "SPP",
+        "notes": "Progress to half-kneeling/staggered stance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Stir-the-Pot (Forearms on Swiss Ball)",
+        "phase": "GPP",
+        "notes": "Small circles"
+      },
+      {
+        "name": "Belt-Assisted Hollow Body Hold",
+        "phase": "GPP",
+        "notes": "Reduce lumbar strain"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Stir-the-Pot (Forearms on Swiss Ball)",
+        "phase": "SPP",
+        "notes": "Larger dynamic patterns"
+      },
+      {
+        "name": "Belt-Assisted Hollow Body Hold",
+        "phase": "SPP",
+        "notes": "Remove belt, add rocking"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Diaphragmatic Breathing with Pelvic Floor Activation",
+        "phase": "GPP",
+        "notes": "Reset intra-abdominal pressure"
+      },
+      {
+        "name": "Supine Marches (Heel Slides)",
+        "phase": "GPP",
+        "notes": "Disassociation training"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Diaphragmatic Breathing with Pelvic Floor Activation",
+        "phase": "TAPER",
+        "notes": "Use pre-competition"
+      },
+      {
+        "name": "Supine Marches (Heel Slides)",
+        "phase": "TAPER",
+        "notes": "Reduce volume"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bear Crawl Isometric (3-Point Hold)",
+        "phase": "GPP",
+        "notes": "15s holds"
+      },
+      {
+        "name": "Weighted Plank (Plate on Back)",
+        "phase": "GPP",
+        "notes": "Time under tension"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bear Crawl Isometric (3-Point Hold)",
+        "phase": "SPP",
+        "notes": "Add contralateral limb lifts"
+      },
+      {
+        "name": "Weighted Plank (Plate on Back)",
+        "phase": "SPP",
+        "notes": "Add instability (Rings/TRX)"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Medicine Ball Rollbacks",
+        "phase": "GPP",
+        "notes": "Eccentric control"
+      },
+      {
+        "name": "Standing Cable Anti-Rotation Press",
+        "phase": "GPP",
+        "notes": "Bilateral stance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Medicine Ball Rollbacks",
+        "phase": "SPP",
+        "notes": "Add catch/throw component"
+      },
+      {
+        "name": "Standing Cable Anti-Rotation Press",
+        "phase": "SPP",
+        "notes": "Single-leg stance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hanging Scapular Retraction Holds",
+        "phase": "GPP",
+        "notes": "Upper core integration"
+      },
+      {
+        "name": "Suitcase Carry (Kettlebell)",
+        "phase": "GPP",
+        "notes": "Loaded anti-lateral flexion"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hanging Scapular Retraction Holds",
+        "phase": "SPP",
+        "notes": "Add leg raises (knees bent)"
+      },
+      {
+        "name": "Suitcase Carry (Kettlebell)",
+        "phase": "SPP",
+        "notes": "Increase distance/speed"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quadruped Belly Drawing",
+        "phase": "GPP",
+        "notes": "TVA activation"
+      },
+      {
+        "name": "Foam Roller Dead Bug (Roller Under Pelvis)",
+        "phase": "GPP",
+        "notes": "Feedback for pelvic stability"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Quadruped Belly Drawing",
+        "phase": "TAPER",
+        "notes": "Reduce to maintenance sets"
+      },
+      {
+        "name": "Foam Roller Dead Bug (Roller Under Pelvis)",
+        "phase": "TAPER",
+        "notes": "Short-duration holds"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "90/90 Breathing with Leg Lowering",
+        "phase": "TAPER",
+        "notes": "Maintain diaphragm-core connection"
+      },
+      {
+        "name": "Banded Resisted Supine Toe Taps",
+        "phase": "TAPER",
+        "notes": "Light neural activation"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Landmine Press",
+        "phase": "GPP",
+        "notes": "Anti-rotation focus"
+      },
+      {
+        "name": "Reverse Hyperextension (Isometric Hold at Top)",
+        "phase": "GPP",
+        "notes": "Posterior chain-core coupling"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Landmine Press",
+        "phase": "SPP",
+        "notes": "Add pulse at end range"
+      },
+      {
+        "name": "Reverse Hyperextension (Isometric Hold at Top)",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Resistance Band (Hands/Knees)",
+        "phase": "GPP",
+        "notes": "Synchronized limb loading"
+      },
+      {
+        "name": "Standing Banded Anti-Flexion Press",
+        "phase": "GPP",
+        "notes": "Resist forward collapse"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Resistance Band (Hands/Knees)",
+        "phase": "SPP",
+        "notes": "Add contralateral reaches"
+      },
+      {
+        "name": "Standing Banded Anti-Flexion Press",
+        "phase": "SPP",
+        "notes": "Single-arm press"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Pelvic Tilts with Balloon Breathing",
+        "phase": "GPP",
+        "notes": "Reset lumbar-pelvic position"
+      },
+      {
+        "name": "Wall Plank Shoulder Taps",
+        "phase": "GPP",
+        "notes": "Core-shoulder integration"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Supine Pelvic Tilts with Balloon Breathing",
+        "phase": "TAPER",
+        "notes": "Daily mobility"
+      },
+      {
+        "name": "Wall Plank Shoulder Taps",
+        "phase": "TAPER",
+        "notes": "Reduce reps"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Compression Breath Holds (5s On/Off)",
+        "phase": "TAPER",
+        "notes": "Intra-abdominal pressure maintenance"
+      },
+      {
+        "name": "Seated Stability Ball Circles",
+        "phase": "TAPER",
+        "notes": "Active recovery focus"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Kneeling Rollout (Ab Wheel/Sliders)",
+        "phase": "GPP",
+        "notes": "Controlled eccentric"
+      },
+      {
+        "name": "Standing Cable Chop (Low to High)",
+        "phase": "GPP",
+        "notes": "Bilateral stance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Kneeling Rollout (Ab Wheel/Sliders)",
+        "phase": "SPP",
+        "notes": "Standing rollout"
+      },
+      {
+        "name": "Standing Cable Chop (Low to High)",
+        "phase": "SPP",
+        "notes": "Split stance"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Prone Cobra with Scapular Retraction",
+        "phase": "GPP",
+        "notes": "Posterior core endurance"
+      },
+      {
+        "name": "Farmer's Carry (Neutral Spine Focus)",
+        "phase": "GPP",
+        "notes": "Loaded stability"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Prone Cobra with Scapular Retraction",
+        "phase": "SPP",
+        "notes": "Add arm/leg lifts"
+      },
+      {
+        "name": "Farmer's Carry (Neutral Spine Focus)",
+        "phase": "SPP",
+        "notes": "Uneven loads"
+      }
+    ]
+  },
+  {
+    "location": "core",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Prone Breathing",
+        "phase": "TAPER",
+        "notes": "Diaphragm release pre-competition"
+      },
+      {
+        "name": "Standing Banded Anti-Extension Press",
+        "phase": "TAPER",
+        "notes": "Light neural priming"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Assisted Elbow Extension Mobilization",
+        "phase": "GPP",
+        "notes": "Improve end-range extension"
+      },
+      {
+        "name": "Pronation/Supination with Dowel",
+        "phase": "GPP",
+        "notes": "Restore rotational ROM"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Assisted Elbow Extension Mobilization",
+        "phase": "SPP",
+        "notes": "Pair with weighted carries"
+      },
+      {
+        "name": "Pronation/Supination with Dowel",
+        "phase": "SPP",
+        "notes": "Add resistance band"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Flexion (Against Wall)",
+        "phase": "GPP",
+        "notes": "30s holds at 50% effort"
+      },
+      {
+        "name": "Forearm Plank on Knees (Elbow Angle Control)",
+        "phase": "GPP",
+        "notes": "Core-elbow integration"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wrist Flexion (Against Wall)",
+        "phase": "SPP",
+        "notes": "Increase angle variability"
+      },
+      {
+        "name": "Forearm Plank on Knees (Elbow Angle Control)",
+        "phase": "SPP",
+        "notes": "Progress to full plank"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Light weight, high reps"
+      },
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "GPP",
+        "notes": "Tendon reloading"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Increase load"
+      },
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "SPP",
+        "notes": "Speed progressions"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Arm Bottle Pour (Water Weight Shifts)",
+        "phase": "GPP",
+        "notes": "Dynamic stability"
+      },
+      {
+        "name": "Unilateral Wall Ball Catch (Soft Ball)",
+        "phase": "GPP",
+        "notes": "Reactive loading"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Arm Bottle Pour (Water Weight Shifts)",
+        "phase": "SPP",
+        "notes": "Add movement complexity"
+      },
+      {
+        "name": "Unilateral Wall Ball Catch (Soft Ball)",
+        "phase": "SPP",
+        "notes": "Increase ball weight"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heat + Passive Extension Stretch",
+        "phase": "TAPER",
+        "notes": "Pre-competition stiffness reduction"
+      },
+      {
+        "name": "Very Light Flexbar Oscillations",
+        "phase": "TAPER",
+        "notes": "Neural activation without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Grip Isometric Holds",
+        "phase": "GPP",
+        "notes": "15s holds"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "GPP",
+        "notes": "Balance flexor/extensor strength"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Grip Isometric Holds",
+        "phase": "SPP",
+        "notes": "Add twists"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "SPP",
+        "notes": "Speed drills"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Overhead Elbow Press (Partial ROM)",
+        "phase": "GPP",
+        "notes": "Scapulo-humeral rhythm"
+      },
+      {
+        "name": "Wall-Assisted Triceps Extension Isometric",
+        "phase": "GPP",
+        "notes": "Mid-range control"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Overhead Elbow Press (Partial ROM)",
+        "phase": "SPP",
+        "notes": "Full ROM"
+      },
+      {
+        "name": "Wall-Assisted Triceps Extension Isometric",
+        "phase": "SPP",
+        "notes": "Eccentric overload"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Median Nerve Sliders",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Radial Nerve Mobilization with Wrist Flexion",
+        "phase": "GPP",
+        "notes": "Improve neural mobility"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Median Nerve Sliders",
+        "phase": "TAPER",
+        "notes": "Maintenance pre-comp"
+      },
+      {
+        "name": "Radial Nerve Mobilization with Wrist Flexion",
+        "phase": "TAPER",
+        "notes": "Lighten intensity"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Plyometric Ball Wall Toss (Underhand)",
+        "phase": "SPP",
+        "notes": "Develop reactive strength"
+      },
+      {
+        "name": "Band-Resisted Rotary Stability Holds",
+        "phase": "SPP",
+        "notes": "Anti-rotation endurance"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Vibration Plate Forearm Stimulation",
+        "phase": "GPP",
+        "notes": "Potential bone density support"
+      },
+      {
+        "name": "Low-Load Blood Flow Restriction (BFR) Wrist Curls",
+        "phase": "GPP",
+        "notes": "20% 1RM for metabolic stimulus"
+      }
+    ]
+  },
+  {
+    "location": "elbow",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Vibration Plate Forearm Stimulation",
+        "phase": "TAPER",
+        "notes": "Reduce frequency"
+      },
+      {
+        "name": "Low-Load Blood Flow Restriction (BFR) Wrist Curls",
+        "phase": "TAPER",
+        "notes": "Eliminate"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Snellen Chart Pursuits (Horizontal/Vertical)",
+        "phase": "GPP",
+        "notes": "Baseline tracking"
+      },
+      {
+        "name": "Diplopia (Double Vision) Correction Drills",
+        "phase": "GPP",
+        "notes": "Prism adaptation if needed"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Snellen Chart Pursuits (Horizontal/Vertical)",
+        "phase": "SPP",
+        "notes": "Add sport-specific background noise"
+      },
+      {
+        "name": "Diplopia (Double Vision) Correction Drills",
+        "phase": "SPP",
+        "notes": "Integrate with head turns"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ballistic Saccades (Dot-to-Dot)",
+        "phase": "GPP",
+        "notes": "Improve rapid refocusing"
+      },
+      {
+        "name": "Stroop Test with Peripheral Awareness",
+        "phase": "GPP",
+        "notes": "Color-word conflict"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Ballistic Saccades (Dot-to-Dot)",
+        "phase": "SPP",
+        "notes": "Add unpredictable patterns"
+      },
+      {
+        "name": "Stroop Test with Peripheral Awareness",
+        "phase": "SPP",
+        "notes": "Add sport cues (e.g., coach signals)"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Brock String Convergence",
+        "phase": "GPP",
+        "notes": "3-bead focus"
+      },
+      {
+        "name": "Virtual Reality Depth Perception Drills",
+        "phase": "GPP",
+        "notes": "Static depth"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Brock String Convergence",
+        "phase": "SPP",
+        "notes": "Add head movement"
+      },
+      {
+        "name": "Virtual Reality Depth Perception Drills",
+        "phase": "SPP",
+        "notes": "Dynamic object tracking"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Photophobia Desensitization (Controlled LED Exposure)",
+        "phase": "GPP",
+        "notes": "Gradual intensity"
+      },
+      {
+        "name": "Pupillary Response Drills (Penlight)",
+        "phase": "GPP",
+        "notes": "Reflex latency"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Photophobia Desensitization (Controlled LED Exposure)",
+        "phase": "TAPER",
+        "notes": "Pre-comp light adaptation"
+      },
+      {
+        "name": "Pupillary Response Drills (Penlight)",
+        "phase": "TAPER",
+        "notes": "Maintain with reduced volume"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reaction Ball Wall Ties (Multi-Color)",
+        "phase": "SPP",
+        "notes": "Color-coded reactions"
+      },
+      {
+        "name": "Peripheral Number Recognition (While Dribbling)",
+        "phase": "SPP",
+        "notes": "Basketball-specific"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "King-Devick Test Practice",
+        "phase": "GPP",
+        "notes": "Baseline"
+      },
+      {
+        "name": "Smooth Pursuit with Cognitive Load",
+        "phase": "GPP",
+        "notes": "Single-task"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "King-Devick Test Practice",
+        "phase": "TAPER",
+        "notes": "Re-test pre-return"
+      },
+      {
+        "name": "Smooth Pursuit with Cognitive Load",
+        "phase": "TAPER",
+        "notes": "Dual-task (sport-specific)"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Blink Rate Reminders (Timer)",
+        "phase": "GPP",
+        "notes": "20/min baseline"
+      },
+      {
+        "name": "Warm Compress + Lid Massage",
+        "phase": "GPP",
+        "notes": "Meibomian gland function"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Blink Rate Reminders (Timer)",
+        "phase": "TAPER",
+        "notes": "Competition reminders"
+      },
+      {
+        "name": "Warm Compress + Lid Massage",
+        "phase": "TAPER",
+        "notes": "Pre-event"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Inhibitory Saccades (Look Away from Cue)",
+        "phase": "GPP",
+        "notes": "Lab setting"
+      },
+      {
+        "name": "Sticky Fixation Drills",
+        "phase": "GPP",
+        "notes": "Maintain gaze under distraction"
+      }
+    ]
+  },
+  {
+    "location": "eye",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Inhibitory Saccades (Look Away from Cue)",
+        "phase": "SPP",
+        "notes": "Sport environment"
+      },
+      {
+        "name": "Sticky Fixation Drills",
+        "phase": "SPP",
+        "notes": "Add motion"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Goldfish Exercises (Partial Opening)",
+        "phase": "GPP",
+        "notes": "Improve jaw tracking"
+      },
+      {
+        "name": "Tongue-to-Palate Isometric Holds",
+        "phase": "GPP",
+        "notes": "10s holds"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Goldfish Exercises (Partial Opening)",
+        "phase": "SPP",
+        "notes": "Add resistance with fingers"
+      },
+      {
+        "name": "Tongue-to-Palate Isometric Holds",
+        "phase": "SPP",
+        "notes": "Combine with head nods"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Smooth Pursuit Tracking (Pen Tracking)",
+        "phase": "GPP",
+        "notes": "Basic eye movements"
+      },
+      {
+        "name": "Convergence/Divergence Drills (Pencil Push-Ups)",
+        "phase": "GPP",
+        "notes": "Binocular coordination"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Smooth Pursuit Tracking (Pen Tracking)",
+        "phase": "SPP",
+        "notes": "Add head movements"
+      },
+      {
+        "name": "Convergence/Divergence Drills (Pencil Push-Ups)",
+        "phase": "SPP",
+        "notes": "Dynamic environments"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Mirror-Assisted Brow Raises",
+        "phase": "GPP",
+        "notes": "Isolate forehead muscles"
+      },
+      {
+        "name": "Cheek Puff Holds with Alternating Sides",
+        "phase": "GPP",
+        "notes": "Buccinator activation"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mirror-Assisted Brow Raises",
+        "phase": "SPP",
+        "notes": "Add resistance"
+      },
+      {
+        "name": "Cheek Puff Holds with Alternating Sides",
+        "phase": "SPP",
+        "notes": "Add phonation"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Chin Tucks with Jaw Relaxation",
+        "phase": "GPP",
+        "notes": "Cervical-face connection"
+      },
+      {
+        "name": "Tongue Rest Position Drills",
+        "phase": "GPP",
+        "notes": "Habit retraining"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chin Tucks with Jaw Relaxation",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      },
+      {
+        "name": "Tongue Rest Position Drills",
+        "phase": "SPP",
+        "notes": "Combine with breathing"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Warm Compress + Gentle Masseter Stretch",
+        "phase": "TAPER",
+        "notes": "Pre-competition relaxation"
+      },
+      {
+        "name": "5-Minute Eye Palming",
+        "phase": "TAPER",
+        "notes": "Visual reset"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Trigeminal Nerve Flossing (Jaw Side Glides)",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Facial Nerve Activation (Whistle-Sip Straw)",
+        "phase": "GPP",
+        "notes": "Oral motor control"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Trigeminal Nerve Flossing (Jaw Side Glides)",
+        "phase": "SPP",
+        "notes": "Combine with cervical movements"
+      },
+      {
+        "name": "Facial Nerve Activation (Whistle-Sip Straw)",
+        "phase": "SPP",
+        "notes": "Complex patterns"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Blink Reflex Training (Feather Touches)",
+        "phase": "GPP",
+        "notes": "Protective responses"
+      },
+      {
+        "name": "Mouthguard Bite Pressure Grading",
+        "phase": "GPP",
+        "notes": "Even force distribution"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Blink Reflex Training (Feather Touches)",
+        "phase": "SPP",
+        "notes": "Unexpected stimuli"
+      },
+      {
+        "name": "Mouthguard Bite Pressure Grading",
+        "phase": "SPP",
+        "notes": "Sport-specific fits"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Nasal Dilator Stretches (Before Training)",
+        "phase": "GPP",
+        "notes": "Improve nasal breathing"
+      },
+      {
+        "name": "Zygomatic Breathing Cues (Smile-Breathe)",
+        "phase": "GPP",
+        "notes": "Reduce grimacing"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Nasal Dilator Stretches (Before Training)",
+        "phase": "TAPER",
+        "notes": "Maintenance"
+      },
+      {
+        "name": "Zygomatic Breathing Cues (Smile-Breathe)",
+        "phase": "TAPER",
+        "notes": "Competition priming"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Gaze Stabilization with Head Turns",
+        "phase": "SPP",
+        "notes": "Combine eye/head movements"
+      },
+      {
+        "name": "Jaw Clench Grading During Balance Drills",
+        "phase": "SPP",
+        "notes": "Reduce bruxism under load"
+      }
+    ]
+  },
+  {
+    "location": "face",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Facial Cupping (Cheekbone Drainage)",
+        "phase": "TAPER",
+        "notes": "Post-competition fluid movement"
+      },
+      {
+        "name": "Cold Spoon Ocular Cooldown",
+        "phase": "TAPER",
+        "notes": "Reduce post-fight puffiness"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Toe Press (Against Wall)",
+        "phase": "GPP",
+        "notes": "10s holds at varying angles"
+      },
+      {
+        "name": "Seated Ankle Alphabet Tracing",
+        "phase": "GPP",
+        "notes": "Restore full ROM"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Toe Press (Against Wall)",
+        "phase": "SPP",
+        "notes": "Add unilateral progressions"
+      },
+      {
+        "name": "Seated Ankle Alphabet Tracing",
+        "phase": "SPP",
+        "notes": "Add light band resistance"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Drops (Straight Knee)",
+        "phase": "GPP",
+        "notes": "3s lowering phase"
+      },
+      {
+        "name": "Towel Scrunches with Toes",
+        "phase": "GPP",
+        "notes": "Intrinsic foot activation"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Drops (Straight Knee)",
+        "phase": "SPP",
+        "notes": "Increase range/depth"
+      },
+      {
+        "name": "Towel Scrunches with Toes",
+        "phase": "SPP",
+        "notes": "Add weight to towel"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Banded Dorsiflexion Mobilizations",
+        "phase": "GPP",
+        "notes": "Improve anterior glide"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Balance on Foam Pad",
+        "phase": "SPP",
+        "notes": "Add head turns or arm movements"
+      },
+      {
+        "name": "Banded Dorsiflexion Mobilizations",
+        "phase": "SPP",
+        "notes": "Integrate into squat patterns"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Plantar Fascia Rolling (Golf Ball)",
+        "phase": "GPP",
+        "notes": "Daily mobility"
+      },
+      {
+        "name": "Calf Stretch with Extended Toes",
+        "phase": "GPP",
+        "notes": "30s holds"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Plantar Fascia Rolling (Golf Ball)",
+        "phase": "TAPER",
+        "notes": "Reduce pressure pre-competition"
+      },
+      {
+        "name": "Calf Stretch with Extended Toes",
+        "phase": "TAPER",
+        "notes": "Shorten duration, increase frequency"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Yoga (Isolated Lifts)",
+        "phase": "GPP",
+        "notes": "Improve toe independence"
+      },
+      {
+        "name": "Standing Tibialis Anterior Holds",
+        "phase": "GPP",
+        "notes": "Isometric at mid-range"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Toe Yoga (Isolated Lifts)",
+        "phase": "SPP",
+        "notes": "Add dynamic movements"
+      },
+      {
+        "name": "Standing Tibialis Anterior Holds",
+        "phase": "SPP",
+        "notes": "Add heel raise transitions"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sliding Arch Activation (Towel Under Midfoot)",
+        "phase": "GPP",
+        "notes": "Controlled arch engagement"
+      },
+      {
+        "name": "Step-Over Toe Touch Drills",
+        "phase": "GPP",
+        "notes": "Improve toe extension"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Sliding Arch Activation (Towel Under Midfoot)",
+        "phase": "SPP",
+        "notes": "Add unilateral stance"
+      },
+      {
+        "name": "Step-Over Toe Touch Drills",
+        "phase": "SPP",
+        "notes": "Increase speed"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bilateral Heel Walks",
+        "phase": "GPP",
+        "notes": "Tibialis anterior endurance"
+      },
+      {
+        "name": "Posterior Tibialis Isometrics (Band-Resisted)",
+        "phase": "GPP",
+        "notes": "Midfoot stability"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bilateral Heel Walks",
+        "phase": "SPP",
+        "notes": "Progress to uneven surfaces"
+      },
+      {
+        "name": "Posterior Tibialis Isometrics (Band-Resisted)",
+        "phase": "SPP",
+        "notes": "Integrate with single-leg balance"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Contrast Baths (Cold/Warm)",
+        "phase": "TAPER",
+        "notes": "Reduce inflammation without overstimulation"
+      },
+      {
+        "name": "Gentle Ankle Circles (Non-Weight Bearing)",
+        "phase": "TAPER",
+        "notes": "Maintain mobility with minimal fatigue"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Spreader Holds (With Rubber Band)",
+        "phase": "GPP",
+        "notes": "Improve splay endurance"
+      },
+      {
+        "name": "Inversion/Eversion Band Resisted Drills",
+        "phase": "GPP",
+        "notes": "Coronal plane control"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Toe Spreader Holds (With Rubber Band)",
+        "phase": "SPP",
+        "notes": "Add weight shifts"
+      },
+      {
+        "name": "Inversion/Eversion Band Resisted Drills",
+        "phase": "SPP",
+        "notes": "Add unstable surfaces"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Self-Massage (Arch Release with Thumb)",
+        "phase": "GPP",
+        "notes": "Daily tissue work"
+      },
+      {
+        "name": "Nighttime Splinting (Neutral Position)",
+        "phase": "GPP",
+        "notes": "Chronic stiffness"
+      }
+    ]
+  },
+  {
+    "location": "foot",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Self-Massage (Arch Release with Thumb)",
+        "phase": "TAPER",
+        "notes": "Lighten pressure"
+      },
+      {
+        "name": "Nighttime Splinting (Neutral Position)",
+        "phase": "TAPER",
+        "notes": "Discontinue 2 days pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Press Isometric Wrist Extension",
+        "phase": "GPP",
+        "notes": "10s holds at multiple angles"
+      },
+      {
+        "name": "Seated Flexion Isometric (Against Knee)",
+        "phase": "GPP",
+        "notes": "Submaximal holds"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Press Isometric Wrist Extension",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "Seated Flexion Isometric (Against Knee)",
+        "phase": "SPP",
+        "notes": "Incorporate grip variations"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Light weight"
+      },
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "GPP",
+        "notes": "Tendon reloading"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Increase load with controlled tempo"
+      },
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "SPP",
+        "notes": "Speed progressions"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Median Nerve Glides (Wrist Oscillations)",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners (Shamrock Pattern)",
+        "phase": "GPP",
+        "notes": "Gentle mobility"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Median Nerve Glides (Wrist Oscillations)",
+        "phase": "TAPER",
+        "notes": "Reduce volume pre-comp"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners (Shamrock Pattern)",
+        "phase": "TAPER",
+        "notes": "Eliminate if irritable"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Rice Bucket Pronation/Supination",
+        "phase": "GPP",
+        "notes": "Endurance focus"
+      },
+      {
+        "name": "Towel Wringing Isometric Holds",
+        "phase": "GPP",
+        "notes": "15s holds"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rice Bucket Pronation/Supination",
+        "phase": "SPP",
+        "notes": "Add resistance"
+      },
+      {
+        "name": "Towel Wringing Isometric Holds",
+        "phase": "SPP",
+        "notes": "Add weight to towel"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Paraffin Wax Therapy",
+        "phase": "TAPER",
+        "notes": "Reduce stiffness without loading"
+      },
+      {
+        "name": "Very Light Flexbar Oscillations",
+        "phase": "TAPER",
+        "notes": "Maintain neural activation"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "BFR Wrist Extensions (20% 1RM)",
+        "phase": "GPP",
+        "notes": "Metabolic stimulus"
+      },
+      {
+        "name": "BFR Finger Flexor Holds",
+        "phase": "GPP",
+        "notes": "Ischemic conditioning"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "BFR Wrist Extensions (20% 1RM)",
+        "phase": "SPP",
+        "notes": "Progressive occlusion"
+      },
+      {
+        "name": "BFR Finger Flexor Holds",
+        "phase": "SPP",
+        "notes": "Reduce frequency"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Weighted Pronation/Supination (Hammer Grip)",
+        "phase": "GPP",
+        "notes": "Controlled ROM"
+      },
+      {
+        "name": "Wall Walking (Fingers to Wrist)",
+        "phase": "GPP",
+        "notes": "Combined mobility"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Weighted Pronation/Supination (Hammer Grip)",
+        "phase": "SPP",
+        "notes": "Add catch/release"
+      },
+      {
+        "name": "Wall Walking (Fingers to Wrist)",
+        "phase": "SPP",
+        "notes": "Increase speed"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Rubber Band Finger Extensions",
+        "phase": "GPP",
+        "notes": "High reps"
+      },
+      {
+        "name": "Dowel Radial/Ulnar Deviation Holds",
+        "phase": "GPP",
+        "notes": "Mid-range stability"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rubber Band Finger Extensions",
+        "phase": "SPP",
+        "notes": "Add rotational component"
+      },
+      {
+        "name": "Dowel Radial/Ulnar Deviation Holds",
+        "phase": "SPP",
+        "notes": "Add perturbations"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Compression Sleeve Flushes",
+        "phase": "TAPER",
+        "notes": "Post-training fluid movement"
+      },
+      {
+        "name": "Contrast Bath Forearm Rolls",
+        "phase": "TAPER",
+        "notes": "Pre-competition circulation boost"
+      }
+    ]
+  },
+  {
+    "location": "forearm",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Hang Grip Endurance",
+        "phase": "SPP",
+        "notes": "Progressive hang times"
+      },
+      {
+        "name": "Plate Pinch Rotations",
+        "phase": "SPP",
+        "notes": "Combined grip/forearm challenge"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Double-Leg Glute Bridge (Isometric Hold)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Quadruped Hip Extension (Band-Resisted)",
+        "phase": "GPP",
+        "notes": "Controlled ROM"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Double-Leg Glute Bridge (Isometric Hold)",
+        "phase": "SPP",
+        "notes": "Add single-leg pulses"
+      },
+      {
+        "name": "Quadruped Hip Extension (Band-Resisted)",
+        "phase": "SPP",
+        "notes": "Add knee flexion"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Sit-to-Stand (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "3s lowering"
+      },
+      {
+        "name": "Step-Up with Posterior Reach",
+        "phase": "GPP",
+        "notes": "Improve hip control"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Sit-to-Stand (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "Step-Up with Posterior Reach",
+        "phase": "SPP",
+        "notes": "Increase height/speed"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Clamshell with Isometric Hold (Top Position)",
+        "phase": "GPP",
+        "notes": "15s holds"
+      },
+      {
+        "name": "Standing Hip CARs (Controlled Rotations)",
+        "phase": "GPP",
+        "notes": "Improve joint awareness"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Clamshell with Isometric Hold (Top Position)",
+        "phase": "SPP",
+        "notes": "Add mini-band resistance"
+      },
+      {
+        "name": "Standing Hip CARs (Controlled Rotations)",
+        "phase": "SPP",
+        "notes": "Add load"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Glute Sweeps (30s/Side)",
+        "phase": "TAPER",
+        "notes": "Maintain tissue mobility"
+      },
+      {
+        "name": "Isometric Wall Lean (Hip Extension)",
+        "phase": "TAPER",
+        "notes": "Activate without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Romanian Deadlift (3s Eccentric)",
+        "phase": "GPP",
+        "notes": "Hamstring-glute coordination"
+      },
+      {
+        "name": "Lateral Lunge with Pause",
+        "phase": "GPP",
+        "notes": "Adductor integration"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Romanian Deadlift (3s Eccentric)",
+        "phase": "SPP",
+        "notes": "Add single-leg"
+      },
+      {
+        "name": "Lateral Lunge with Pause",
+        "phase": "SPP",
+        "notes": "Increase depth"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Fire Hydrant Circles (Mini-Band)",
+        "phase": "GPP",
+        "notes": "Multi-planar activation"
+      },
+      {
+        "name": "Glute-Medius Isometric Holds (Side-Lying)",
+        "phase": "GPP",
+        "notes": "45s holds"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Fire Hydrant Circles (Mini-Band)",
+        "phase": "SPP",
+        "notes": "Add ankle weights"
+      },
+      {
+        "name": "Glute-Medius Isometric Holds (Side-Lying)",
+        "phase": "SPP",
+        "notes": "Add leg abduction"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg RDL with Overhead Reach",
+        "phase": "SPP",
+        "notes": "Integrate kinetic chain"
+      },
+      {
+        "name": "Lateral Bound with Stick Landing",
+        "phase": "SPP",
+        "notes": "Develop reactive strength"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "90/90 Hip Stretch with Glute Engagement",
+        "phase": "GPP",
+        "notes": "Improve IR/ER"
+      },
+      {
+        "name": "Piriformis Self-Release (Ball)",
+        "phase": "GPP",
+        "notes": "2min/side"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "90/90 Hip Stretch with Glute Engagement",
+        "phase": "TAPER",
+        "notes": "Reduce hold time"
+      },
+      {
+        "name": "Piriformis Self-Release (Ball)",
+        "phase": "TAPER",
+        "notes": "Light pressure only"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Suitcase Carry (Contralateral Load)",
+        "phase": "GPP",
+        "notes": "Anti-lateral flexion"
+      },
+      {
+        "name": "Overhead Farmer's Walk",
+        "phase": "GPP",
+        "notes": "Core-glute integration"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Suitcase Carry (Contralateral Load)",
+        "phase": "SPP",
+        "notes": "Increase distance"
+      },
+      {
+        "name": "Overhead Farmer's Walk",
+        "phase": "SPP",
+        "notes": "Add uneven loads"
+      }
+    ]
+  },
+  {
+    "location": "glutes",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Quick Clamshell Pulses (No Resistance)",
+        "phase": "TAPER",
+        "notes": "Maintain neural drive"
+      },
+      {
+        "name": "Standing Glute Squeeze with Breath Hold",
+        "phase": "TAPER",
+        "notes": "Pre-activity priming"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Adductor Squeeze (Ball Between Knees)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Side-Lying Adductor Raises",
+        "phase": "GPP",
+        "notes": "Short-lever"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Adductor Squeeze (Ball Between Knees)",
+        "phase": "SPP",
+        "notes": "Add pulses or unstable surface"
+      },
+      {
+        "name": "Side-Lying Adductor Raises",
+        "phase": "SPP",
+        "notes": "Add ankle weights"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Copenhagen Plank Eccentric Lowers",
+        "phase": "GPP",
+        "notes": "3s lowering"
+      },
+      {
+        "name": "Seated Adductor Machine Eccentrics",
+        "phase": "GPP",
+        "notes": "Light load"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Copenhagen Plank Eccentric Lowers",
+        "phase": "SPP",
+        "notes": "Full range eccentrics"
+      },
+      {
+        "name": "Seated Adductor Machine Eccentrics",
+        "phase": "SPP",
+        "notes": "Increase time under tension"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Adductor Mobilizations",
+        "phase": "GPP",
+        "notes": "Rocking movements"
+      },
+      {
+        "name": "Frog Stretch with Pulsed Contractions",
+        "phase": "GPP",
+        "notes": "PNF techniques"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Adductor Mobilizations",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      },
+      {
+        "name": "Frog Stretch with Pulsed Contractions",
+        "phase": "SPP",
+        "notes": "Active holds"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Romanian Deadlifts (Narrow Stance)",
+        "phase": "GPP",
+        "notes": "Control"
+      },
+      {
+        "name": "Lateral Lunge with Isometric Hold",
+        "phase": "GPP",
+        "notes": "5s holds"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Romanian Deadlifts (Narrow Stance)",
+        "phase": "SPP",
+        "notes": "Add contralateral rotation"
+      },
+      {
+        "name": "Lateral Lunge with Isometric Hold",
+        "phase": "SPP",
+        "notes": "Explosive return"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Adductor Flossing",
+        "phase": "TAPER",
+        "notes": "Light mobility pre-competition"
+      },
+      {
+        "name": "Standing Adductor Isometrics (Low Intensity)",
+        "phase": "TAPER",
+        "notes": "Maintain tension without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Adductor Activation",
+        "phase": "GPP",
+        "notes": "Co-contraction"
+      },
+      {
+        "name": "Pallof Press with Lateral Step",
+        "phase": "GPP",
+        "notes": "Anti-rotation"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Adductor Activation",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "Pallof Press with Lateral Step",
+        "phase": "SPP",
+        "notes": "Increase band tension"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rotational Medicine Ball Throws (Staggered Stance)",
+        "phase": "SPP",
+        "notes": "Develop transverse plane power"
+      },
+      {
+        "name": "Crossover Step-Ups with Knee Drive",
+        "phase": "SPP",
+        "notes": "Sport-specific patterning"
+      }
+    ]
+  },
+  {
+    "location": "groin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "BFR Adductor Curls (20% 1RM)",
+        "phase": "GPP",
+        "notes": "Metabolic stimulus without heavy load"
+      },
+      {
+        "name": "BFR Seated Marches",
+        "phase": "GPP",
+        "notes": "Maintain hip flexor-adductor coordination"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Hamstring Bridge Hold (30s)",
+        "phase": "GPP",
+        "notes": "Mid-range activation"
+      },
+      {
+        "name": "Sliding Leg Curls (Towel on Floor)",
+        "phase": "GPP",
+        "notes": "Eccentric focus"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Hamstring Bridge Hold (30s)",
+        "phase": "SPP",
+        "notes": "Add single-leg pulses"
+      },
+      {
+        "name": "Sliding Leg Curls (Towel on Floor)",
+        "phase": "SPP",
+        "notes": "Increase tempo control"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Standing Bent-Knee Stretch (Active ROM)",
+        "phase": "GPP",
+        "notes": "Dynamic mobility"
+      },
+      {
+        "name": "Seated Band-Resisted Knee Flexion",
+        "phase": "GPP",
+        "notes": "Light concentric work"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Bent-Knee Stretch (Active ROM)",
+        "phase": "SPP",
+        "notes": "Add rotation component"
+      },
+      {
+        "name": "Seated Band-Resisted Knee Flexion",
+        "phase": "SPP",
+        "notes": "Progress to standing"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Nordic Hamstring Curl Eccentrics",
+        "phase": "GPP",
+        "notes": "3s lowering"
+      },
+      {
+        "name": "Single-Leg Romanian Deadlift (TRX Assisted)",
+        "phase": "GPP",
+        "notes": "Controlled range"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Nordic Hamstring Curl Eccentrics",
+        "phase": "SPP",
+        "notes": "Add concentric assistance (bands)"
+      },
+      {
+        "name": "Single-Leg Romanian Deadlift (TRX Assisted)",
+        "phase": "SPP",
+        "notes": "Add weights"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Hamstring Sweeps",
+        "phase": "GPP",
+        "notes": "Tissue prep"
+      },
+      {
+        "name": "Dynamic PNF Stretching",
+        "phase": "GPP",
+        "notes": "Contract-relax"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Hamstring Sweeps",
+        "phase": "TAPER",
+        "notes": "Reduce pressure pre-comp"
+      },
+      {
+        "name": "Dynamic PNF Stretching",
+        "phase": "TAPER",
+        "notes": "Shorten duration"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Swiss Ball Hamstring Curls",
+        "phase": "GPP",
+        "notes": "Bilateral stability"
+      },
+      {
+        "name": "Kettlebell Swing (Hinge Pattern Focus)",
+        "phase": "GPP",
+        "notes": "Teach hip dissociation"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Swiss Ball Hamstring Curls",
+        "phase": "SPP",
+        "notes": "Unilateral progressions"
+      },
+      {
+        "name": "Kettlebell Swing (Hinge Pattern Focus)",
+        "phase": "SPP",
+        "notes": "Increase explosiveness"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Isometric Knee Extension (Heel Dig)",
+        "phase": "GPP",
+        "notes": "Co-contraction training"
+      },
+      {
+        "name": "Lateral Lunge with Hamstring Emphasis",
+        "phase": "GPP",
+        "notes": "Multiplane loading"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine Isometric Knee Extension (Heel Dig)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      },
+      {
+        "name": "Lateral Lunge with Hamstring Emphasis",
+        "phase": "SPP",
+        "notes": "Add deceleration focus"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Good Morning (Isometric Hold at 45\u00b0)",
+        "phase": "GPP",
+        "notes": "Posterior chain endurance"
+      },
+      {
+        "name": "Reverse Hyperextension (Floor Version)",
+        "phase": "GPP",
+        "notes": "Low-load activation"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Good Morning (Isometric Hold at 45\u00b0)",
+        "phase": "SPP",
+        "notes": "Dynamic reps"
+      },
+      {
+        "name": "Reverse Hyperextension (Floor Version)",
+        "phase": "SPP",
+        "notes": "Add ankle weights"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heat Wrap + Gentle Static Stretch",
+        "phase": "TAPER",
+        "notes": "Maintain mobility without fatigue"
+      },
+      {
+        "name": "Mini-Band Walks (Monster Walks)",
+        "phase": "TAPER",
+        "notes": "Glute-hamstring coactivation"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Slider Leg Curl (3s Lower)",
+        "phase": "GPP",
+        "notes": "Targeted lengthening"
+      },
+      {
+        "name": "Standing Hamstring Isometric (Against Wall)",
+        "phase": "GPP",
+        "notes": "Functional angle holds"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Slider Leg Curl (3s Lower)",
+        "phase": "SPP",
+        "notes": "Add pause at end-range"
+      },
+      {
+        "name": "Standing Hamstring Isometric (Against Wall)",
+        "phase": "SPP",
+        "notes": "Add contralateral movements"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Self-Massage (Theracane Trigger Points)",
+        "phase": "GPP",
+        "notes": "Weekly maintenance"
+      },
+      {
+        "name": "Aqua Jogging (High Knee Focus)",
+        "phase": "GPP",
+        "notes": "Non-impact conditioning"
+      }
+    ]
+  },
+  {
+    "location": "hamstring",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Self-Massage (Theracane Trigger Points)",
+        "phase": "TAPER",
+        "notes": "Lighten pressure"
+      },
+      {
+        "name": "Aqua Jogging (High Knee Focus)",
+        "phase": "TAPER",
+        "notes": "Reduce volume"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Twist Isometric Holds",
+        "phase": "GPP",
+        "notes": "30s crush grip"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "GPP",
+        "notes": "Balance flexor/extensor ratio"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Twist Isometric Holds",
+        "phase": "SPP",
+        "notes": "Add wrist rotations during hold"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "SPP",
+        "notes": "Speed drills post-clinch"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Plate Pinch Transfers",
+        "phase": "GPP",
+        "notes": "5lb plate"
+      },
+      {
+        "name": "Wrist Roller (Reverse Winding)",
+        "phase": "GPP",
+        "notes": "Eccentric forearm control"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Plate Pinch Transfers",
+        "phase": "SPP",
+        "notes": "Textured plates for mat realism"
+      },
+      {
+        "name": "Wrist Roller (Reverse Winding)",
+        "phase": "SPP",
+        "notes": "Increase rope weight"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up Holds",
+        "phase": "GPP",
+        "notes": "15s mid-range"
+      },
+      {
+        "name": "Band-Resisted Wrist Deviations",
+        "phase": "GPP",
+        "notes": "Radial/ulnar endurance"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up Holds",
+        "phase": "SPP",
+        "notes": "Add unstable surface (foam pad)"
+      },
+      {
+        "name": "Band-Resisted Wrist Deviations",
+        "phase": "SPP",
+        "notes": "Mimic parry angles"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Sledgehammer Levering",
+        "phase": "GPP",
+        "notes": "Start at hammerhead"
+      },
+      {
+        "name": "Finger Walkout Planks",
+        "phase": "GPP",
+        "notes": "Wrist-load tolerance"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Sledgehammer Levering",
+        "phase": "TAPER",
+        "notes": "Lighten to handle-only"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Micro-Fracture Rice Digs",
+        "phase": "GPP",
+        "notes": "Progressive density exposure"
+      },
+      {
+        "name": "Light Bag Tapping (Open Palm)",
+        "phase": "GPP",
+        "notes": "Desensitize"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Micro-Fracture Rice Digs",
+        "phase": "SPP",
+        "notes": "Vary textures (sand/beans)"
+      },
+      {
+        "name": "Light Bag Tapping (Open Palm)",
+        "phase": "SPP",
+        "notes": "Progress to closed fist"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reactive Ball Catching (Uneven Bounces)",
+        "phase": "SPP",
+        "notes": "Improve knuckle impact timing"
+      },
+      {
+        "name": "Taped Wrist Shadowboxing",
+        "phase": "SPP",
+        "notes": "Reinforce neutral alignment during strikes"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Key Pinch Isometrics",
+        "phase": "GPP",
+        "notes": "10s holds"
+      },
+      {
+        "name": "Thumb Opposition Crawls",
+        "phase": "GPP",
+        "notes": "Mobility"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Key Pinch Isometrics",
+        "phase": "SPP",
+        "notes": "Add lateral pull resistance"
+      },
+      {
+        "name": "Thumb Opposition Crawls",
+        "phase": "SPP",
+        "notes": "Speed under fatigue"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "CMC Joint Mobilization (Band-Distracted)",
+        "phase": "GPP",
+        "notes": "Improve thumb saddle ROM"
+      },
+      {
+        "name": "Towel Thumb Rolls",
+        "phase": "GPP",
+        "notes": "Endurance"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "CMC Joint Mobilization (Band-Distracted)",
+        "phase": "TAPER",
+        "notes": "Lighten band tension"
+      },
+      {
+        "name": "Towel Thumb Rolls",
+        "phase": "TAPER",
+        "notes": "Reduce volume pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Paraffin Wax Therapy",
+        "phase": "TAPER",
+        "notes": "Post-sparring joint recovery"
+      },
+      {
+        "name": "Contrast Baths (30s Hot/10s Cold)",
+        "phase": "TAPER",
+        "notes": "Flush metabolic waste between rounds"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Flexor Gliding",
+        "phase": "GPP",
+        "notes": "Prevent tendon adhesions"
+      },
+      {
+        "name": "Nighttime Buddy Taping",
+        "phase": "GPP",
+        "notes": "Chronic MCP protection"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Finger Flexor Gliding",
+        "phase": "TAPER",
+        "notes": "Maintenance"
+      },
+      {
+        "name": "Nighttime Buddy Taping",
+        "phase": "TAPER",
+        "notes": "Discontinue fight week"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Median Nerve Flossing",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners",
+        "phase": "GPP",
+        "notes": "Prevent cubital tunnel"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Median Nerve Flossing",
+        "phase": "SPP",
+        "notes": "Combine with shoulder retraction"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners",
+        "phase": "SPP",
+        "notes": "Add grip component"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dynasplint Wrist Extension",
+        "phase": "GPP",
+        "notes": "Passive ROM"
+      },
+      {
+        "name": "Tendon Gliding Series",
+        "phase": "GPP",
+        "notes": "Post-impact recovery"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dynasplint Wrist Extension",
+        "phase": "SPP",
+        "notes": "Active-assisted"
+      },
+      {
+        "name": "Tendon Gliding Series",
+        "phase": "SPP",
+        "notes": "Pre-competition prep"
+      }
+    ]
+  },
+  {
+    "location": "hand",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Clinch Grip Endurance Hangs",
+        "phase": "SPP",
+        "notes": "60s timed overhand hangs"
+      },
+      {
+        "name": "Rotational Wrist Wrenching",
+        "phase": "SPP",
+        "notes": "Gi-grip simulation"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Heel Press (Against Wall)",
+        "phase": "GPP",
+        "notes": "15s holds at pain-free angle"
+      },
+      {
+        "name": "Towel Stretch with Knee Extended",
+        "phase": "GPP",
+        "notes": "Static gastrocnemius stretch"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Heel Press (Against Wall)",
+        "phase": "SPP",
+        "notes": "Increase hold duration"
+      },
+      {
+        "name": "Towel Stretch with Knee Extended",
+        "phase": "SPP",
+        "notes": "Add pulsed contractions"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Raises (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Double-leg"
+      },
+      {
+        "name": "Seated Plantar Fascia Stretch (Toe Extension)",
+        "phase": "GPP",
+        "notes": "Manual tension"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Heel Raises (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Progress to single-leg"
+      },
+      {
+        "name": "Seated Plantar Fascia Stretch (Toe Extension)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Heel Walks (20 Steps)",
+        "phase": "GPP",
+        "notes": "Tibialis anterior activation"
+      },
+      {
+        "name": "Banded Heel Cord Mobilization",
+        "phase": "GPP",
+        "notes": "Posterior chain glide"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Heel Walks (20 Steps)",
+        "phase": "SPP",
+        "notes": "Increase distance/speed"
+      },
+      {
+        "name": "Banded Heel Cord Mobilization",
+        "phase": "SPP",
+        "notes": "Integrate into squat patterns"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Golf Ball Roll Under Heel",
+        "phase": "GPP",
+        "notes": "Daily tissue mobilization"
+      },
+      {
+        "name": "Night Splint (Neutral Position)",
+        "phase": "GPP",
+        "notes": "Chronic stiffness"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Golf Ball Roll Under Heel",
+        "phase": "TAPER",
+        "notes": "Reduce pressure"
+      },
+      {
+        "name": "Night Splint (Neutral Position)",
+        "phase": "TAPER",
+        "notes": "Discontinue pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "heel",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Warm Water Soak with Epsom Salt",
+        "phase": "TAPER",
+        "notes": "Pre-competition circulation boost"
+      },
+      {
+        "name": "Light Calf Pump Ankle Pumps",
+        "phase": "TAPER",
+        "notes": "Maintain mobility without load"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Glute Bridge Hold (30\u00b0 Hip Extension)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Standing Hip CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Improve joint awareness"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Glute Bridge Hold (30\u00b0 Hip Extension)",
+        "phase": "SPP",
+        "notes": "Add marching or single-leg pulses"
+      },
+      {
+        "name": "Standing Hip CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Add resistance band"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Lateral Lunge (3s Descent)",
+        "phase": "GPP",
+        "notes": "Frontal plane control"
+      },
+      {
+        "name": "Quadruped Hip Circunduction",
+        "phase": "GPP",
+        "notes": "Mobilize capsule"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Lateral Lunge (3s Descent)",
+        "phase": "SPP",
+        "notes": "Add explosive return"
+      },
+      {
+        "name": "Quadruped Hip Circunduction",
+        "phase": "SPP",
+        "notes": "Load with ankle weight"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Stance with Hip ER/IR",
+        "phase": "GPP",
+        "notes": "Rotational stability"
+      },
+      {
+        "name": "90/90 Hip Switch with Posterior Tilt",
+        "phase": "GPP",
+        "notes": "Internal/external ROM"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Stance with Hip ER/IR",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "90/90 Hip Switch with Posterior Tilt",
+        "phase": "SPP",
+        "notes": "Add reach component"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Psoas March with Band Resistance",
+        "phase": "GPP",
+        "notes": "Improve iliacus coordination"
+      },
+      {
+        "name": "Supine Figure-4 PIR Stretch",
+        "phase": "GPP",
+        "notes": "30s holds"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Psoas March with Band Resistance",
+        "phase": "TAPER",
+        "notes": "Reduce band tension"
+      },
+      {
+        "name": "Supine Figure-4 PIR Stretch",
+        "phase": "TAPER",
+        "notes": "Decrease hold duration"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Copenhagen Plank (Adductor Focus)",
+        "phase": "GPP",
+        "notes": "Isometric strength"
+      },
+      {
+        "name": "Seated Hip CARS with Dowel Assistance",
+        "phase": "GPP",
+        "notes": "Passive ROM"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Copenhagen Plank (Adductor Focus)",
+        "phase": "SPP",
+        "notes": "Add dynamic movements"
+      },
+      {
+        "name": "Seated Hip CARS with Dowel Assistance",
+        "phase": "SPP",
+        "notes": "Active control"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Lateral Line Sliders (Glute Med Activation)",
+        "phase": "GPP",
+        "notes": "Unilateral control"
+      },
+      {
+        "name": "Deadbug with Hip Airplane",
+        "phase": "GPP",
+        "notes": "Core-hip dissociation"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Lateral Line Sliders (Glute Med Activation)",
+        "phase": "SPP",
+        "notes": "Add directional changes"
+      },
+      {
+        "name": "Deadbug with Hip Airplane",
+        "phase": "SPP",
+        "notes": "Add weights"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Standing Hip Flexor Stretch with Posterior Tilt",
+        "phase": "GPP",
+        "notes": "2min accumulative"
+      },
+      {
+        "name": "Side-Lying Clamshell with Pause",
+        "phase": "GPP",
+        "notes": "2s hold at top"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Hip Flexor Stretch with Posterior Tilt",
+        "phase": "SPP",
+        "notes": "Integrate with rotation"
+      },
+      {
+        "name": "Side-Lying Clamshell with Pause",
+        "phase": "SPP",
+        "notes": "Add loop band"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller TFL Release (30s)",
+        "phase": "TAPER",
+        "notes": "Reduce tension without overstimulation"
+      },
+      {
+        "name": "Supine Diaphragmatic Breathing with Hip Capsule",
+        "phase": "TAPER",
+        "notes": "Neural reset pre-competition"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Hip Flexor Isometrics",
+        "phase": "GPP",
+        "notes": "Build anterior chain stability"
+      },
+      {
+        "name": "Standing Hip Hike with Control",
+        "phase": "GPP",
+        "notes": "Pelvic control"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Hip Flexor Isometrics",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      },
+      {
+        "name": "Standing Hip Hike with Control",
+        "phase": "SPP",
+        "notes": "Add step-down component"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Piriformis Self-Massage (Ball)",
+        "phase": "GPP",
+        "notes": "Daily maintenance"
+      },
+      {
+        "name": "Standing Windmill Toe Touches",
+        "phase": "GPP",
+        "notes": "Combined mobility"
+      }
+    ]
+  },
+  {
+    "location": "hip",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Piriformis Self-Massage (Ball)",
+        "phase": "TAPER",
+        "notes": "Light pressure only"
+      },
+      {
+        "name": "Standing Windmill Toe Touches",
+        "phase": "TAPER",
+        "notes": "Reduce range pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Goldfish Exercise (Assisted Opening)",
+        "phase": "GPP",
+        "notes": "Improve joint tracking"
+      },
+      {
+        "name": "Tongue-to-Palate Isometric Holds",
+        "phase": "GPP",
+        "notes": "10s holds"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Goldfish Exercise (Assisted Opening)",
+        "phase": "SPP",
+        "notes": "Add resistance fingers"
+      },
+      {
+        "name": "Tongue-to-Palate Isometric Holds",
+        "phase": "SPP",
+        "notes": "Combine with cervical nods"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Controlled Chin Tucks with Jaw Relaxation",
+        "phase": "GPP",
+        "notes": "Postural integration"
+      },
+      {
+        "name": "Masseter Self-Massage (Circular Pressure)",
+        "phase": "GPP",
+        "notes": "Reduce hypertonicity"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Controlled Chin Tucks with Jaw Relaxation",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      },
+      {
+        "name": "Masseter Self-Massage (Circular Pressure)",
+        "phase": "SPP",
+        "notes": "Pre-activity release"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "6-Way Jaw Isometrics (Finger Resistance)",
+        "phase": "GPP",
+        "notes": "Pain-modulation"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "6-Way Jaw Isometrics (Finger Resistance)",
+        "phase": "TAPER",
+        "notes": "Reduce hold duration"
+      },
+      {
+        "name": "Warm Compress + Passive Stretching",
+        "phase": "TAPER",
+        "notes": "Pre-competition relaxation"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bite Force Grading (Cotton Roll)",
+        "phase": "GPP",
+        "notes": "Neuromuscular re-education"
+      },
+      {
+        "name": "Mandibular Lateral Glides (Controlled)",
+        "phase": "GPP",
+        "notes": "Improve side-to-side mobility"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bite Force Grading (Cotton Roll)",
+        "phase": "SPP",
+        "notes": "Vary textures"
+      },
+      {
+        "name": "Mandibular Lateral Glides (Controlled)",
+        "phase": "SPP",
+        "notes": "Add resistance"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Chewing Gum Alternating Patterns",
+        "phase": "GPP",
+        "notes": "Bilateral coordination"
+      },
+      {
+        "name": "Diaphragmatic Breathing with Jaw Relaxation",
+        "phase": "GPP",
+        "notes": "Reduce parafunctional habits"
+      }
+    ]
+  },
+  {
+    "location": "jaw",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chewing Gum Alternating Patterns",
+        "phase": "SPP",
+        "notes": "Increase viscosity"
+      },
+      {
+        "name": "Diaphragmatic Breathing with Jaw Relaxation",
+        "phase": "SPP",
+        "notes": "Integrate with movement"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug Isometric Hold (Knees at 90\u00b0)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Front Plank with Posterior Pelvic Tilt",
+        "phase": "GPP",
+        "notes": "Teach lumbo-pelvic control"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug Isometric Hold (Knees at 90\u00b0)",
+        "phase": "SPP",
+        "notes": "Add limb oscillations"
+      },
+      {
+        "name": "Front Plank with Posterior Pelvic Tilt",
+        "phase": "SPP",
+        "notes": "Add shoulder taps"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Cat-Cow (Isolated Lumbar Flex/Ext)",
+        "phase": "GPP",
+        "notes": "Improve segmental control"
+      },
+      {
+        "name": "Quadruped Rockbacks (Hips to Heels)",
+        "phase": "GPP",
+        "notes": "Mobilize thoracolumbar junction"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Cat-Cow (Isolated Lumbar Flex/Ext)",
+        "phase": "SPP",
+        "notes": "Add resistance bands"
+      },
+      {
+        "name": "Quadruped Rockbacks (Hips to Heels)",
+        "phase": "SPP",
+        "notes": "Load with sandbag"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "3-Point Kneeling Hip Hinge (3s Lower)",
+        "phase": "GPP",
+        "notes": "Teach hip-dominant pattern"
+      },
+      {
+        "name": "Swiss Ball Rollouts (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "Partial ROM"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "3-Point Kneeling Hip Hinge (3s Lower)",
+        "phase": "SPP",
+        "notes": "Progress to standing"
+      },
+      {
+        "name": "Swiss Ball Rollouts (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Full extension with control"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank with Adductor Squeeze",
+        "phase": "GPP",
+        "notes": "20s holds"
+      },
+      {
+        "name": "Bird Dog with Band Resistance",
+        "phase": "GPP",
+        "notes": "Anti-rotation"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank with Adductor Squeeze",
+        "phase": "SPP",
+        "notes": "Add leg lifts"
+      },
+      {
+        "name": "Bird Dog with Band Resistance",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Child's Pose with Diaphragmatic Breathing",
+        "phase": "TAPER",
+        "notes": "Parasympathetic activation"
+      },
+      {
+        "name": "Standing Extension Mobilizations (Over Peanut)",
+        "phase": "TAPER",
+        "notes": "Light facet joint decompression"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Slump Glides",
+        "phase": "GPP",
+        "notes": "Improve neural sliding"
+      },
+      {
+        "name": "Prone Sciatic Flossing",
+        "phase": "GPP",
+        "notes": "2x/day"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Slump Glides",
+        "phase": "SPP",
+        "notes": "Add ankle dorsiflexion"
+      },
+      {
+        "name": "Prone Sciatic Flossing",
+        "phase": "SPP",
+        "notes": "Integrate with hip CARs"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Landmine Rotations",
+        "phase": "GPP",
+        "notes": "Light load"
+      },
+      {
+        "name": "Deadlift Pattern with Dowel (Hip Contact)",
+        "phase": "GPP",
+        "notes": "Teach bar path"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Half-Kneeling Landmine Rotations",
+        "phase": "SPP",
+        "notes": "Increase ROM/speed"
+      },
+      {
+        "name": "Deadlift Pattern with Dowel (Hip Contact)",
+        "phase": "SPP",
+        "notes": "Load with kettlebells"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Suitcase Carry (Contralateral Loading)",
+        "phase": "GPP",
+        "notes": "30s walks"
+      },
+      {
+        "name": "Reverse Hyperextension (Isometric Hold)",
+        "phase": "GPP",
+        "notes": "Glute-hamstring activation"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Suitcase Carry (Contralateral Loading)",
+        "phase": "SPP",
+        "notes": "Increase weight/distance"
+      },
+      {
+        "name": "Reverse Hyperextension (Isometric Hold)",
+        "phase": "SPP",
+        "notes": "Add pulses"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hooklying Marching (Heel Slides)",
+        "phase": "GPP",
+        "notes": "Morning stiffness relief"
+      },
+      {
+        "name": "Piriformis PNF Stretching",
+        "phase": "GPP",
+        "notes": "2min holds"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Hooklying Marching (Heel Slides)",
+        "phase": "TAPER",
+        "notes": "Reduce volume"
+      },
+      {
+        "name": "Piriformis PNF Stretching",
+        "phase": "TAPER",
+        "notes": "Lighten intensity"
+      }
+    ]
+  },
+  {
+    "location": "lower_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Pallof Press with Step-Outs",
+        "phase": "SPP",
+        "notes": "Dynamic core bracing under load"
+      },
+      {
+        "name": "Rotational Medicine Ball Throws",
+        "phase": "SPP",
+        "notes": "Develop power with maintained neutral spine"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side Plank Isometric Hold (Knees Bent)",
+        "phase": "GPP",
+        "notes": "20s holds"
+      },
+      {
+        "name": "Seated Band-Resisted Rotation (Isometric)",
+        "phase": "GPP",
+        "notes": "Hold mid-range"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side Plank Isometric Hold (Knees Bent)",
+        "phase": "SPP",
+        "notes": "Progress to straight legs or add hip abduction"
+      },
+      {
+        "name": "Seated Band-Resisted Rotation (Isometric)",
+        "phase": "SPP",
+        "notes": "Add pulsing movements"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Oblique Focus (Slow Lowering)",
+        "phase": "GPP",
+        "notes": "3s eccentric"
+      },
+      {
+        "name": "Pallof Press Isometric Hold",
+        "phase": "GPP",
+        "notes": "Anti-rotation stability"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dead Bug with Oblique Focus (Slow Lowering)",
+        "phase": "SPP",
+        "notes": "Add unstable surface (foam pad)"
+      },
+      {
+        "name": "Pallof Press Isometric Hold",
+        "phase": "SPP",
+        "notes": "Add step-outs"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side-Lying Windmill Stretch (Active)",
+        "phase": "GPP",
+        "notes": "Improve rotational ROM"
+      },
+      {
+        "name": "Standing Cable Chop (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "3s lowering"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side-Lying Windmill Stretch (Active)",
+        "phase": "SPP",
+        "notes": "Add light dumbbell"
+      },
+      {
+        "name": "Standing Cable Chop (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Increase load/speed"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Lateral Flexion Mobilization",
+        "phase": "GPP",
+        "notes": "Tissue release"
+      },
+      {
+        "name": "Brettzel Stretch with Breathing",
+        "phase": "GPP",
+        "notes": "Thoracic-oblique mobility"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Lateral Flexion Mobilization",
+        "phase": "TAPER",
+        "notes": "Gentle maintenance"
+      },
+      {
+        "name": "Brettzel Stretch with Breathing",
+        "phase": "TAPER",
+        "notes": "Short holds pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "obliques",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Standing Side Bend Isometric (Bodyweight)",
+        "phase": "TAPER",
+        "notes": "Low-fatigue tension maintenance"
+      },
+      {
+        "name": "Supine Diaphragmatic Breathing with Rib Expansion",
+        "phase": "TAPER",
+        "notes": "Reset oblique-rib cage relationship"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Chin Tuck Isometric Hold (Against Wall)",
+        "phase": "GPP",
+        "notes": "10s holds"
+      },
+      {
+        "name": "Side-Lying Neck Isometrics (Hand Resistance)",
+        "phase": "GPP",
+        "notes": "Multi-angle holds"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Chin Tuck Isometric Hold (Against Wall)",
+        "phase": "SPP",
+        "notes": "Add nodding movements"
+      },
+      {
+        "name": "Side-Lying Neck Isometrics (Hand Resistance)",
+        "phase": "SPP",
+        "notes": "Increase duration"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Cervical CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Daily mobility"
+      },
+      {
+        "name": "Supine Neck Glides (Towel Roll Support)",
+        "phase": "GPP",
+        "notes": "Segmental mobility"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Cervical CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Add light band resistance"
+      },
+      {
+        "name": "Supine Neck Glides (Towel Roll Support)",
+        "phase": "SPP",
+        "notes": "Reduce support"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Scapular Retraction + Neck Extension",
+        "phase": "GPP",
+        "notes": "Postural chain activation"
+      },
+      {
+        "name": "Quadruped Cervical Clock Rotations",
+        "phase": "GPP",
+        "notes": "Combine neck/shoulder control"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Scapular Retraction + Neck Extension",
+        "phase": "SPP",
+        "notes": "Add arm movements"
+      },
+      {
+        "name": "Quadruped Cervical Clock Rotations",
+        "phase": "SPP",
+        "notes": "Add limb lifts"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heat Pack + Gentle Lateral Flexion Stretch",
+        "phase": "TAPER",
+        "notes": "Pre-competition stiffness reduction"
+      },
+      {
+        "name": "TheraCane Trigger Point Release (30s)",
+        "phase": "TAPER",
+        "notes": "Light maintenance work"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Chin Tuck (3s Lower from Extension)",
+        "phase": "GPP",
+        "notes": "Control through full ROM"
+      },
+      {
+        "name": "Prone Head Lift with Slow Lowering",
+        "phase": "GPP",
+        "notes": "Posterior chain focus"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Chin Tuck (3s Lower from Extension)",
+        "phase": "SPP",
+        "notes": "Add manual resistance"
+      },
+      {
+        "name": "Prone Head Lift with Slow Lowering",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Head Tracking (Follow Thumb)",
+        "phase": "GPP",
+        "notes": "Basic oculomotor-neck coordination"
+      },
+      {
+        "name": "Standing Balance with Head Turns",
+        "phase": "GPP",
+        "notes": "Static"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Head Tracking (Follow Thumb)",
+        "phase": "SPP",
+        "notes": "Add trunk rotation"
+      },
+      {
+        "name": "Standing Balance with Head Turns",
+        "phase": "SPP",
+        "notes": "Dynamic surface progressions"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Median Nerve Glide (With Cervical Side Bend)",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Supine Occipital Release (Tennis Ball)",
+        "phase": "GPP",
+        "notes": "Suboccipital tension"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Median Nerve Glide (With Cervical Side Bend)",
+        "phase": "TAPER",
+        "notes": "Reduce repetitions"
+      },
+      {
+        "name": "Supine Occipital Release (Tennis Ball)",
+        "phase": "TAPER",
+        "notes": "Light pressure only"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Rotation Holds (At 50% ROM)",
+        "phase": "GPP",
+        "notes": "Build rotational stability"
+      },
+      {
+        "name": "Seated Thoracic Rotation + Neck Tracking",
+        "phase": "GPP",
+        "notes": "Dissociate cervical/thoracic movement"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Rotation Holds (At 50% ROM)",
+        "phase": "SPP",
+        "notes": "Add resistance bands"
+      },
+      {
+        "name": "Seated Thoracic Rotation + Neck Tracking",
+        "phase": "SPP",
+        "notes": "Add load"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Supine Head Float (2\" Off Surface)",
+        "phase": "GPP",
+        "notes": "Anterior chain endurance"
+      },
+      {
+        "name": "Standing Wall Lean (Forehead Contact)",
+        "phase": "GPP",
+        "notes": "Progressive loading"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Supine Head Float (2\" Off Surface)",
+        "phase": "SPP",
+        "notes": "Add nodding motions"
+      },
+      {
+        "name": "Standing Wall Lean (Forehead Contact)",
+        "phase": "SPP",
+        "notes": "Single-leg stance"
+      }
+    ]
+  },
+  {
+    "location": "neck",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pec Minor Doorway Stretch (With Chin Tuck)",
+        "phase": "TAPER",
+        "notes": "Address compensatory tightness"
+      },
+      {
+        "name": "Cervical Traction (Over Bed Edge)",
+        "phase": "TAPER",
+        "notes": "Gentle decompression pre-competition"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Sit (60\u00b0 Knee Flexion)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Sliding Leg Extensions (Towel Under Foot)",
+        "phase": "GPP",
+        "notes": "Controlled ROM"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Wall Sit (60\u00b0 Knee Flexion)",
+        "phase": "SPP",
+        "notes": "Add band resistance or unilateral pulses"
+      },
+      {
+        "name": "Sliding Leg Extensions (Towel Under Foot)",
+        "phase": "SPP",
+        "notes": "Increase speed/tempo"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Step-Downs (3s Lowering)",
+        "phase": "GPP",
+        "notes": "12-15 reps"
+      },
+      {
+        "name": "Quadruped Rockbacks (Knee Over Toe)",
+        "phase": "GPP",
+        "notes": "Improve end-range tolerance"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Step-Downs (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Add rotation or external load"
+      },
+      {
+        "name": "Quadruped Rockbacks (Knee Over Toe)",
+        "phase": "SPP",
+        "notes": "Add band distraction"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Spanish Squat Isometric Holds",
+        "phase": "GPP",
+        "notes": "Reduce patellar load"
+      },
+      {
+        "name": "Sled Drags (Forward Lean Emphasis)",
+        "phase": "GPP",
+        "notes": "Low-impact loading"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Spanish Squat Isometric Holds",
+        "phase": "SPP",
+        "notes": "Add pulses or mini jumps"
+      },
+      {
+        "name": "Sled Drags (Forward Lean Emphasis)",
+        "phase": "SPP",
+        "notes": "Increase incline/load"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Quad Smash + Mobilizations",
+        "phase": "GPP",
+        "notes": "Daily tissue work"
+      },
+      {
+        "name": "Standing Quad Stretch (With Hip Extension)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Foam Roller Quad Smash + Mobilizations",
+        "phase": "TAPER",
+        "notes": "Reduce pressure pre-comp"
+      },
+      {
+        "name": "Standing Quad Stretch (With Hip Extension)",
+        "phase": "TAPER",
+        "notes": "Short duration, frequent sessions"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (Band-Resisted)",
+        "phase": "GPP",
+        "notes": "End-range control"
+      },
+      {
+        "name": "Pause Squats (90\u00b0 Hold)",
+        "phase": "GPP",
+        "notes": "3s pause"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Terminal Knee Extensions (Band-Resisted)",
+        "phase": "SPP",
+        "notes": "Integrate into lunges"
+      },
+      {
+        "name": "Pause Squats (90\u00b0 Hold)",
+        "phase": "SPP",
+        "notes": "Add explosive concentric"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Sit-to-Stand (Eccentric Focus)",
+        "phase": "GPP",
+        "notes": "4s lowering"
+      },
+      {
+        "name": "Blood Flow Restriction (BFR) Leg Extensions",
+        "phase": "GPP",
+        "notes": "20% 1RM for metabolic stimulus"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Sit-to-Stand (Eccentric Focus)",
+        "phase": "SPP",
+        "notes": "Reduce assistance"
+      },
+      {
+        "name": "Blood Flow Restriction (BFR) Leg Extensions",
+        "phase": "SPP",
+        "notes": "Progressive loading"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Peterson Step-Ups (Controlled Descent)",
+        "phase": "GPP",
+        "notes": "Patellar tracking focus"
+      },
+      {
+        "name": "Mini-Band Resisted Knee Drives",
+        "phase": "GPP",
+        "notes": "Hip-quad coordination"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Peterson Step-Ups (Controlled Descent)",
+        "phase": "SPP",
+        "notes": "Increase height/speed"
+      },
+      {
+        "name": "Mini-Band Resisted Knee Drives",
+        "phase": "SPP",
+        "notes": "Sport-specific angles"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Low-Load Isokinetic Bike Sprints",
+        "phase": "TAPER",
+        "notes": "Maintain neuromuscular firing without fatigue"
+      },
+      {
+        "name": "Quadriceps Flossing (Voodoo Wrap)",
+        "phase": "TAPER",
+        "notes": "Pre-competition tissue mobilization"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "TKE (Terminal Knee Extension) Walks",
+        "phase": "GPP",
+        "notes": "Gait integration"
+      },
+      {
+        "name": "Decline Board Eccentric Squats",
+        "phase": "GPP",
+        "notes": "Tibial angle emphasis"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "TKE (Terminal Knee Extension) Walks",
+        "phase": "SPP",
+        "notes": "Add lateral movements"
+      },
+      {
+        "name": "Decline Board Eccentric Squats",
+        "phase": "SPP",
+        "notes": "Add external load"
+      }
+    ]
+  },
+  {
+    "location": "quads",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Contrast Therapy (Heat/Ice Rotation)",
+        "phase": "TAPER",
+        "notes": "Inflammation modulation"
+      },
+      {
+        "name": "Assisted Deep Squat Holds",
+        "phase": "TAPER",
+        "notes": "Maintain ROM without loading"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Toe Raises (Dorsiflexion)",
+        "phase": "GPP",
+        "notes": "3x15 light reps"
+      },
+      {
+        "name": "Heel Walks (20m)",
+        "phase": "GPP",
+        "notes": "Build endurance"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Toe Raises (Dorsiflexion)",
+        "phase": "SPP",
+        "notes": "Add band resistance or tempo"
+      },
+      {
+        "name": "Heel Walks (20m)",
+        "phase": "SPP",
+        "notes": "Progress to uneven surfaces"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Toe Lowering (3s Count)",
+        "phase": "GPP",
+        "notes": "Control foot pronation"
+      },
+      {
+        "name": "Step-Off Tibialis Drops (Partial ROM)",
+        "phase": "GPP",
+        "notes": "Reduce impact stress"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Toe Lowering (3s Count)",
+        "phase": "SPP",
+        "notes": "Add weight vest"
+      },
+      {
+        "name": "Step-Off Tibialis Drops (Partial ROM)",
+        "phase": "SPP",
+        "notes": "Increase depth"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Tibialis Isometric Hold (Mid-Range)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Toe Drag Isometrics (Towel Resistance)",
+        "phase": "GPP",
+        "notes": "Multi-directional holds"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Tibialis Isometric Hold (Mid-Range)",
+        "phase": "SPP",
+        "notes": "Add pulses"
+      },
+      {
+        "name": "Toe Drag Isometrics (Towel Resistance)",
+        "phase": "SPP",
+        "notes": "Increase duration"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Anterior Compartment Foam Rolling",
+        "phase": "GPP",
+        "notes": "Daily tissue work"
+      },
+      {
+        "name": "Ankle Pump Series (Seated)",
+        "phase": "GPP",
+        "notes": "Improve circulation"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Anterior Compartment Foam Rolling",
+        "phase": "TAPER",
+        "notes": "Reduce pressure"
+      },
+      {
+        "name": "Ankle Pump Series (Seated)",
+        "phase": "TAPER",
+        "notes": "Use as warmup"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Leg Toe Taps (Slow Eccentric)",
+        "phase": "GPP",
+        "notes": "3s lowering"
+      },
+      {
+        "name": "Unilateral Heel Walk (10m)",
+        "phase": "GPP",
+        "notes": "Address asymmetries"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Leg Toe Taps (Slow Eccentric)",
+        "phase": "SPP",
+        "notes": "Add lateral reaches"
+      },
+      {
+        "name": "Unilateral Heel Walk (10m)",
+        "phase": "SPP",
+        "notes": "Carry light weight"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Mini Trampoline Toe Bounces",
+        "phase": "GPP",
+        "notes": "Low-amplitude rebounds"
+      },
+      {
+        "name": "Submaximal Jump Rope (Double Unders)",
+        "phase": "GPP",
+        "notes": "Introduce rhythm"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Mini Trampoline Toe Bounces",
+        "phase": "SPP",
+        "notes": "Increase height"
+      },
+      {
+        "name": "Submaximal Jump Rope (Double Unders)",
+        "phase": "SPP",
+        "notes": "Progress to singles"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Compression Sleeve Flush (Post-Training)",
+        "phase": "TAPER",
+        "notes": "Reduce fluid retention"
+      },
+      {
+        "name": "Gentle Percussion Massage (30s/Side)",
+        "phase": "TAPER",
+        "notes": "Maintain tissue quality without soreness"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "BFR Toe Extensions (20% 1RM)",
+        "phase": "GPP",
+        "notes": "Metabolic stimulus"
+      },
+      {
+        "name": "BFR Calf Raises (Partial ROM)",
+        "phase": "GPP",
+        "notes": "Combined anterior/posterior work"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "BFR Toe Extensions (20% 1RM)",
+        "phase": "SPP",
+        "notes": "Reduce frequency"
+      },
+      {
+        "name": "BFR Calf Raises (Partial ROM)",
+        "phase": "SPP",
+        "notes": "Phase out"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Ankle CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Daily joint health"
+      },
+      {
+        "name": "Resisted Ankle Dorsiflexion (Band)",
+        "phase": "GPP",
+        "notes": "Improve swing phase mechanics"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Ankle CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Add load"
+      },
+      {
+        "name": "Resisted Ankle Dorsiflexion (Band)",
+        "phase": "SPP",
+        "notes": "Speed work"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Night Splint (Neutral Position)",
+        "phase": "GPP",
+        "notes": "Chronic stiffness"
+      },
+      {
+        "name": "Elevation + Ice Gel Pack (Post-Load)",
+        "phase": "GPP",
+        "notes": "Acute inflammation"
+      }
+    ]
+  },
+  {
+    "location": "shin",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Night Splint (Neutral Position)",
+        "phase": "TAPER",
+        "notes": "Discontinue pre-comp"
+      },
+      {
+        "name": "Elevation + Ice Gel Pack (Post-Load)",
+        "phase": "TAPER",
+        "notes": "Replace with warmth"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Isometric Straight Arm Hold (Jab Position)",
+        "phase": "GPP",
+        "notes": "15s holds at 90% extension"
+      },
+      {
+        "name": "Eccentric Banded Hook Recovery (3s Return)",
+        "phase": "GPP",
+        "notes": "Control return phase"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Isometric Straight Arm Hold (Jab Position)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      },
+      {
+        "name": "Eccentric Banded Hook Recovery (3s Return)",
+        "phase": "SPP",
+        "notes": "Mimic head movement"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Rotator Cuff Isometrics at 90\u00b0 Abduction",
+        "phase": "GPP",
+        "notes": "Stability in punching ROM"
+      },
+      {
+        "name": "Wall-Guided Overhead Press (Partial ROM)",
+        "phase": "GPP",
+        "notes": "Rebuild vertical push"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rotator Cuff Isometrics at 90\u00b0 Abduction",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      },
+      {
+        "name": "Wall-Guided Overhead Press (Partial ROM)",
+        "phase": "SPP",
+        "notes": "Full ROM under control"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Grip Isometric Holds (Overhead)",
+        "phase": "GPP",
+        "notes": "20s gi/clinch simulation"
+      },
+      {
+        "name": "Prone Trap-3 Raises (Grappling Initiation)",
+        "phase": "GPP",
+        "notes": "Scapular retraction endurance"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Grip Isometric Holds (Overhead)",
+        "phase": "SPP",
+        "notes": "Add partner pulls"
+      },
+      {
+        "name": "Prone Trap-3 Raises (Grappling Initiation)",
+        "phase": "SPP",
+        "notes": "Add rotation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Kettlebell Arm Bar (Bottom-Up)",
+        "phase": "GPP",
+        "notes": "Shoulder capsule mobility"
+      },
+      {
+        "name": "Supine Shoulder Tap Drills",
+        "phase": "GPP",
+        "notes": "Guard posture endurance"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Kettlebell Arm Bar (Bottom-Up)",
+        "phase": "SPP",
+        "notes": "Add active rotations"
+      },
+      {
+        "name": "Supine Shoulder Tap Drills",
+        "phase": "SPP",
+        "notes": "Add hip elevation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Medicine Ball Catch at 90\u00b0 Abduction",
+        "phase": "GPP",
+        "notes": "2kg ball"
+      },
+      {
+        "name": "Eccentric Push-Up Lowering (3s to Mat)",
+        "phase": "GPP",
+        "notes": "Fall absorption"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Medicine Ball Catch at 90\u00b0 Abduction",
+        "phase": "SPP",
+        "notes": "Increase weight/speed"
+      },
+      {
+        "name": "Eccentric Push-Up Lowering (3s to Mat)",
+        "phase": "SPP",
+        "notes": "Single-arm eccentrics"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Punch Decelerations",
+        "phase": "GPP",
+        "notes": "Control hyperextension"
+      },
+      {
+        "name": "Wall-Assisted Scapular Impact Drills",
+        "phase": "GPP",
+        "notes": "Light taps"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Punch Decelerations",
+        "phase": "SPP",
+        "notes": "Add combos"
+      },
+      {
+        "name": "Wall-Assisted Scapular Impact Drills",
+        "phase": "SPP",
+        "notes": "Increase force gradually"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Armcare\u00ae Routine (Reduced Volume)",
+        "phase": "TAPER",
+        "notes": "Maintain mobility without fatigue"
+      },
+      {
+        "name": "Contrast Shoulder Immersion (30s Hot/Cold)",
+        "phase": "TAPER",
+        "notes": "Pre-fight inflammation management"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Neural Flossing for Brachial Plexus",
+        "phase": "TAPER",
+        "notes": "Reduce nerve irritation pre-comp"
+      },
+      {
+        "name": "Pec Minor Doorway Stretch (30s)",
+        "phase": "TAPER",
+        "notes": "Counteract guard posture"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Arm Landmine Rotations",
+        "phase": "GPP",
+        "notes": "Core-shoulder integration"
+      },
+      {
+        "name": "Kneeling Banded Face Pulls",
+        "phase": "GPP",
+        "notes": "Rear delt activation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Arm Landmine Rotations",
+        "phase": "SPP",
+        "notes": "Add unstable stance"
+      },
+      {
+        "name": "Kneeling Banded Face Pulls",
+        "phase": "SPP",
+        "notes": "Add head movement"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Turkish Get-Up (Half-Kneeling Only)",
+        "phase": "GPP",
+        "notes": "Controlled transitions"
+      },
+      {
+        "name": "Seated Dumbbell External Rotation w/ Hip Flexion",
+        "phase": "GPP",
+        "notes": "Isolate rotators"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Turkish Get-Up (Half-Kneeling Only)",
+        "phase": "SPP",
+        "notes": "Full get-up"
+      },
+      {
+        "name": "Seated Dumbbell External Rotation w/ Hip Flexion",
+        "phase": "SPP",
+        "notes": "Add punch simulation"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Post-Session Dead Hang (20s)",
+        "phase": "GPP",
+        "notes": "Decompress joint"
+      },
+      {
+        "name": "Sleeper Stretch w/ Active Assistance",
+        "phase": "GPP",
+        "notes": "Maintain IR ROM"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Post-Session Dead Hang (20s)",
+        "phase": "TAPER",
+        "notes": "Reduce to 10s"
+      },
+      {
+        "name": "Sleeper Stretch w/ Active Assistance",
+        "phase": "TAPER",
+        "notes": "Lighten pressure"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wall Slides w/ Tennis Ball Chin Tuck",
+        "phase": "GPP",
+        "notes": "Scapulohumeral rhythm"
+      },
+      {
+        "name": "Blackburn Banded Series (Prone)",
+        "phase": "GPP",
+        "notes": "Endurance in retraction"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wall Slides w/ Tennis Ball Chin Tuck",
+        "phase": "SPP",
+        "notes": "Add resistance band"
+      },
+      {
+        "name": "Blackburn Banded Series (Prone)",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quadruped T-Spine Rotations w/ Punch Reach",
+        "phase": "GPP",
+        "notes": "Dissociate scapulothoracic movement"
+      },
+      {
+        "name": "Foam Roller Lat Stretch w/ Shoulder Circles",
+        "phase": "GPP",
+        "notes": "Improve overhead mobility"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Quadruped T-Spine Rotations w/ Punch Reach",
+        "phase": "SPP",
+        "notes": "Add resistance band"
+      },
+      {
+        "name": "Foam Roller Lat Stretch w/ Shoulder Circles",
+        "phase": "SPP",
+        "notes": "Integrate breathing patterns"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Shoulder Distraction Walks",
+        "phase": "GPP",
+        "notes": "Anterior capsule mobilization"
+      },
+      {
+        "name": "Wall-Assisted GH Joint Circles (Small to Large)",
+        "phase": "GPP",
+        "notes": "Controlled circumduction"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Shoulder Distraction Walks",
+        "phase": "SPP",
+        "notes": "Add rotational steps"
+      },
+      {
+        "name": "Wall-Assisted GH Joint Circles (Small to Large)",
+        "phase": "SPP",
+        "notes": "Increase speed gradually"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Kneeling Armbar Mobility Flow",
+        "phase": "GPP",
+        "notes": "Progressive end-range exposure"
+      },
+      {
+        "name": "Supine Shoulder Figure-8s (With Dowel)",
+        "phase": "GPP",
+        "notes": "Enhance rotational capacity"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Kneeling Armbar Mobility Flow",
+        "phase": "SPP",
+        "notes": "Add partner pressure"
+      },
+      {
+        "name": "Supine Shoulder Figure-8s (With Dowel)",
+        "phase": "SPP",
+        "notes": "Narrow grip width"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dynamic Cross-Body Arm Swings (With Counter-Rotation)",
+        "phase": "GPP",
+        "notes": "Prepare for hook mechanics"
+      },
+      {
+        "name": "Resisted Jab-Retract Mobilizations",
+        "phase": "GPP",
+        "notes": "Band-resisted protraction/retraction"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dynamic Cross-Body Arm Swings (With Counter-Rotation)",
+        "phase": "SPP",
+        "notes": "Add weighted vest (\u22645kg)"
+      },
+      {
+        "name": "Resisted Jab-Retract Mobilizations",
+        "phase": "SPP",
+        "notes": "Mimic head movement"
+      }
+    ]
+  },
+  {
+    "location": "shoulder",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pec Minor Release w/ Lacrosse Ball + Arm Sweeps",
+        "phase": "TAPER",
+        "notes": "Post-training stiffness reduction"
+      },
+      {
+        "name": "Heat-Assisted Capsular Stretches (Sidelying)",
+        "phase": "TAPER",
+        "notes": "Pre-competition ROM maintenance"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Isometric Hold)",
+        "phase": "GPP",
+        "notes": "10s holds"
+      },
+      {
+        "name": "Toe Extension Mobilizations (Manual Assist)",
+        "phase": "GPP",
+        "notes": "Restore dorsal glide"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Scrunches (Isometric Hold)",
+        "phase": "SPP",
+        "notes": "Add weight to towel"
+      },
+      {
+        "name": "Toe Extension Mobilizations (Manual Assist)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Marble Pickups (With Toes)",
+        "phase": "GPP",
+        "notes": "Precision control"
+      },
+      {
+        "name": "Toe Splay Isometrics (Rubber Band Resistance)",
+        "phase": "GPP",
+        "notes": "5s holds"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Marble Pickups (With Toes)",
+        "phase": "SPP",
+        "notes": "Timed challenges"
+      },
+      {
+        "name": "Toe Splay Isometrics (Rubber Band Resistance)",
+        "phase": "SPP",
+        "notes": "Progressive band thickness"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single Toe Lifts (Isolated Extension)",
+        "phase": "GPP",
+        "notes": "Individual toe control"
+      },
+      {
+        "name": "Plantar Flexion Pushes (Against Wall)",
+        "phase": "GPP",
+        "notes": "Strength end-range"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single Toe Lifts (Isolated Extension)",
+        "phase": "SPP",
+        "notes": "Add weight shifts"
+      },
+      {
+        "name": "Plantar Flexion Pushes (Against Wall)",
+        "phase": "SPP",
+        "notes": "Eccentric focus"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Spreader Night Splint",
+        "phase": "GPP",
+        "notes": "Chronic alignment"
+      },
+      {
+        "name": "Warm Water Toe Circles",
+        "phase": "GPP",
+        "notes": "Morning mobility"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Toe Spreader Night Splint",
+        "phase": "TAPER",
+        "notes": "Reduce wear time pre-comp"
+      },
+      {
+        "name": "Warm Water Toe Circles",
+        "phase": "TAPER",
+        "notes": "Pre-activity prep"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Toe Flexion/Extension",
+        "phase": "GPP",
+        "notes": "Light resistance"
+      },
+      {
+        "name": "Tactile Discrimination Drills (Texture Identification)",
+        "phase": "GPP",
+        "notes": "Sensory reintegration"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Toe Flexion/Extension",
+        "phase": "SPP",
+        "notes": "Increase tempo"
+      },
+      {
+        "name": "Tactile Discrimination Drills (Texture Identification)",
+        "phase": "SPP",
+        "notes": "Dynamic surfaces"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Toe Yoga (Sequential Lifting)",
+        "phase": "GPP",
+        "notes": "Neuromuscular control"
+      },
+      {
+        "name": "Weight-Bearing Toe Press Holds",
+        "phase": "GPP",
+        "notes": "15s holds"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Toe Yoga (Sequential Lifting)",
+        "phase": "SPP",
+        "notes": "Speed variations"
+      },
+      {
+        "name": "Weight-Bearing Toe Press Holds",
+        "phase": "SPP",
+        "notes": "Single-leg progressions"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Metatarsal Dome Isometrics",
+        "phase": "GPP",
+        "notes": "Arch integration"
+      },
+      {
+        "name": "Toe Walking (Short Distances)",
+        "phase": "GPP",
+        "notes": "Strength endurance"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Metatarsal Dome Isometrics",
+        "phase": "SPP",
+        "notes": "Add movement"
+      },
+      {
+        "name": "Toe Walking (Short Distances)",
+        "phase": "SPP",
+        "notes": "Incline surfaces"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Toe Traction (Manual or Band-Assisted)",
+        "phase": "TAPER",
+        "notes": "Light joint decompression"
+      },
+      {
+        "name": "Paraffin Wax Bath for Toe Joints",
+        "phase": "TAPER",
+        "notes": "Pre-competition stiffness reduction"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dynamic Toe Spreading (With Movement)",
+        "phase": "GPP",
+        "notes": "Active splay"
+      },
+      {
+        "name": "Toe Tapping Drills (Alternating)",
+        "phase": "GPP",
+        "notes": "Coordination"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dynamic Toe Spreading (With Movement)",
+        "phase": "SPP",
+        "notes": "Resistance challenges"
+      },
+      {
+        "name": "Toe Tapping Drills (Alternating)",
+        "phase": "SPP",
+        "notes": "Speed/rhythm variations"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Self-Massage (Interosseous Spaces)",
+        "phase": "GPP",
+        "notes": "Daily tissue work"
+      },
+      {
+        "name": "Contrast Baths (Toes Only)",
+        "phase": "GPP",
+        "notes": "Inflammation control"
+      }
+    ]
+  },
+  {
+    "location": "toe",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Self-Massage (Interosseous Spaces)",
+        "phase": "TAPER",
+        "notes": "Gentle pressure"
+      },
+      {
+        "name": "Contrast Baths (Toes Only)",
+        "phase": "TAPER",
+        "notes": "Pre-event"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bench Dip Isometric Hold (90\u00b0 Elbow)",
+        "phase": "GPP",
+        "notes": "20s holds"
+      },
+      {
+        "name": "Wall Push Hold (Halfway Position)",
+        "phase": "GPP",
+        "notes": "Teach triceps engagement"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bench Dip Isometric Hold (90\u00b0 Elbow)",
+        "phase": "SPP",
+        "notes": "Add scapular depression component"
+      },
+      {
+        "name": "Wall Push Hold (Halfway Position)",
+        "phase": "SPP",
+        "notes": "Progress to uneven surfaces"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "3-Second Eccentric Overhead DB Extension",
+        "phase": "GPP",
+        "notes": "Light weight"
+      },
+      {
+        "name": "Band-Resisted Push-Up Negatives",
+        "phase": "GPP",
+        "notes": "Control descent"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "3-Second Eccentric Overhead DB Extension",
+        "phase": "SPP",
+        "notes": "Increase ROM to full stretch"
+      },
+      {
+        "name": "Band-Resisted Push-Up Negatives",
+        "phase": "SPP",
+        "notes": "Add explosive concentric"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Single-Arm Cable Pressdown (With Rotation)",
+        "phase": "GPP",
+        "notes": "Anti-rotation focus"
+      },
+      {
+        "name": "Unilateral Floor Skull Crusher (Partial ROM)",
+        "phase": "GPP",
+        "notes": "Reduce joint stress"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Single-Arm Cable Pressdown (With Rotation)",
+        "phase": "SPP",
+        "notes": "Increase speed"
+      },
+      {
+        "name": "Unilateral Floor Skull Crusher (Partial ROM)",
+        "phase": "SPP",
+        "notes": "Full ROM with tempo"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Long Head Stretch (Overhead)",
+        "phase": "GPP",
+        "notes": "Improve tissue extensibility"
+      },
+      {
+        "name": "Foam Roller Triceps Sweeps",
+        "phase": "GPP",
+        "notes": "Daily myofascial release"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Banded Long Head Stretch (Overhead)",
+        "phase": "TAPER",
+        "notes": "Shorten duration"
+      },
+      {
+        "name": "Foam Roller Triceps Sweeps",
+        "phase": "TAPER",
+        "notes": "Use massage gun instead"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Light Band Triceps Flows (Continuous Motion)",
+        "phase": "TAPER",
+        "notes": "Maintain neural connection without fatigue"
+      },
+      {
+        "name": "Heat Pack + Passive Stretching",
+        "phase": "TAPER",
+        "notes": "Pre-competition tissue prep"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Bear Crawl Triceps Press (Hands Elevated)",
+        "phase": "GPP",
+        "notes": "Closed-chain stability"
+      },
+      {
+        "name": "Kneeling Landmine Press",
+        "phase": "GPP",
+        "notes": "Rotational component"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Bear Crawl Triceps Press (Hands Elevated)",
+        "phase": "SPP",
+        "notes": "Lower elevation"
+      },
+      {
+        "name": "Kneeling Landmine Press",
+        "phase": "SPP",
+        "notes": "Increase load"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Radial Nerve Glides (With Wrist Flexion)",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Ulnar Nerve Sliders (Elbow Circles)",
+        "phase": "GPP",
+        "notes": "Improve neural mobility"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Radial Nerve Glides (With Wrist Flexion)",
+        "phase": "SPP",
+        "notes": "Combine with triceps extension"
+      },
+      {
+        "name": "Ulnar Nerve Sliders (Elbow Circles)",
+        "phase": "SPP",
+        "notes": "Add shoulder abduction"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "BFR Triceps Pressdowns (20% 1RM)",
+        "phase": "GPP",
+        "notes": "Metabolic stimulus"
+      },
+      {
+        "name": "BFR Overhead Rope Extensions",
+        "phase": "GPP",
+        "notes": "Long head focus"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "BFR Triceps Pressdowns (20% 1RM)",
+        "phase": "SPP",
+        "notes": "Reduce frequency"
+      },
+      {
+        "name": "BFR Overhead Rope Extensions",
+        "phase": "SPP",
+        "notes": "Progressive occlusion"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "TRX Triceps Extensions (High Reps)",
+        "phase": "GPP",
+        "notes": "15-20 reps"
+      },
+      {
+        "name": "Suspension Trainer Overhead Extensions",
+        "phase": "GPP",
+        "notes": "Bodyweight control"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "TRX Triceps Extensions (High Reps)",
+        "phase": "SPP",
+        "notes": "Add tempo variations"
+      },
+      {
+        "name": "Suspension Trainer Overhead Extensions",
+        "phase": "SPP",
+        "notes": "Single-leg stance"
+      }
+    ]
+  },
+  {
+    "location": "triceps",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Percussion Therapy (Lateral Head Focus)",
+        "phase": "TAPER",
+        "notes": "Post-training flush"
+      },
+      {
+        "name": "Compression Sleeve Wear (Recovery Days)",
+        "phase": "TAPER",
+        "notes": "Reduce DOMS between sessions"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Thoracic Extension Over Foam Roller",
+        "phase": "GPP",
+        "notes": "Improve segmental mobility"
+      },
+      {
+        "name": "Scapular Wall Slides (Arms at 45\u00b0)",
+        "phase": "GPP",
+        "notes": "Retraction/depression control"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Thoracic Extension Over Foam Roller",
+        "phase": "SPP",
+        "notes": "Add rotational component"
+      },
+      {
+        "name": "Scapular Wall Slides (Arms at 45\u00b0)",
+        "phase": "SPP",
+        "notes": "Add band resistance"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Quadruped Thoracic Rotations",
+        "phase": "GPP",
+        "notes": "Unilateral rotation focus"
+      },
+      {
+        "name": "Prone Y-W-T Isometric Holds",
+        "phase": "GPP",
+        "notes": "15s holds per position"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Quadruped Thoracic Rotations",
+        "phase": "SPP",
+        "notes": "Add reach-through component"
+      },
+      {
+        "name": "Prone Y-W-T Isometric Holds",
+        "phase": "SPP",
+        "notes": "Add light weights"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Banded Face Pulls with External Rotation",
+        "phase": "GPP",
+        "notes": "High reps (15-20)"
+      },
+      {
+        "name": "Dead Hang Scapular Depressions",
+        "phase": "GPP",
+        "notes": "5s holds"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Banded Face Pulls with External Rotation",
+        "phase": "SPP",
+        "notes": "Increase tension + add pause"
+      },
+      {
+        "name": "Dead Hang Scapular Depressions",
+        "phase": "SPP",
+        "notes": "Add eccentric lowering"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Upper Trapezius Stretch (Contralateral Tilt)",
+        "phase": "GPP",
+        "notes": "30s holds"
+      },
+      {
+        "name": "Levator Scapulae Release (Tennis Ball)",
+        "phase": "GPP",
+        "notes": "Daily tissue work"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Upper Trapezius Stretch (Contralateral Tilt)",
+        "phase": "TAPER",
+        "notes": "Reduce to maintenance frequency"
+      },
+      {
+        "name": "Levator Scapulae Release (Tennis Ball)",
+        "phase": "TAPER",
+        "notes": "Light pressure only"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Standing Thoracic Windmills (With Dowel)",
+        "phase": "GPP",
+        "notes": "Improve cross-body mobility"
+      },
+      {
+        "name": "Seated Cable Row with Scapular Isometrics",
+        "phase": "GPP",
+        "notes": "Mid-range holds"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Standing Thoracic Windmills (With Dowel)",
+        "phase": "SPP",
+        "notes": "Add eyes-closed challenge"
+      },
+      {
+        "name": "Seated Cable Row with Scapular Isometrics",
+        "phase": "SPP",
+        "notes": "Full ROM with tempo"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Foam Roller Snow Angels",
+        "phase": "GPP",
+        "notes": "Controlled ROM"
+      },
+      {
+        "name": "Standing Resistance Band Pull-Aparts",
+        "phase": "GPP",
+        "notes": "High reps"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Foam Roller Snow Angels",
+        "phase": "SPP",
+        "notes": "Add head lift component"
+      },
+      {
+        "name": "Standing Resistance Band Pull-Aparts",
+        "phase": "SPP",
+        "notes": "Add rotational step-throughs"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Child's Pose with Lateral Reaches",
+        "phase": "GPP",
+        "notes": "Multidirectional stretch"
+      },
+      {
+        "name": "Bent-Over Scapular Protraction/Retraction",
+        "phase": "GPP",
+        "notes": "Bodyweight"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Child's Pose with Lateral Reaches",
+        "phase": "SPP",
+        "notes": "Add contralateral glute engagement"
+      },
+      {
+        "name": "Bent-Over Scapular Protraction/Retraction",
+        "phase": "SPP",
+        "notes": "Add dumbbell counterbalance"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Heat Pack Application + Gentle Neck Retractions",
+        "phase": "TAPER",
+        "notes": "Pre-competition stiffness reduction"
+      },
+      {
+        "name": "Standing Wall Angels (Limited ROM)",
+        "phase": "TAPER",
+        "notes": "Maintain mobility without fatigue"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Seated Thoracic Extension with Diaphragmatic Breathing",
+        "phase": "GPP",
+        "notes": "Rib cage mobility"
+      },
+      {
+        "name": "Latissimus Stretch with Foam Roller Support",
+        "phase": "GPP",
+        "notes": "30s holds"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Seated Thoracic Extension with Diaphragmatic Breathing",
+        "phase": "SPP",
+        "notes": "Add overhead reach"
+      },
+      {
+        "name": "Latissimus Stretch with Foam Roller Support",
+        "phase": "SPP",
+        "notes": "Incorporate rotational bias"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Self-Massage (Thoracic Spine with Peanut Ball)",
+        "phase": "GPP",
+        "notes": "Segmental release"
+      },
+      {
+        "name": "Standing Scapular Clock Drills (No Weight)",
+        "phase": "GPP",
+        "notes": "Neuromuscular control"
+      }
+    ]
+  },
+  {
+    "location": "upper_back",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Self-Massage (Thoracic Spine with Peanut Ball)",
+        "phase": "TAPER",
+        "notes": "Light pressure only"
+      },
+      {
+        "name": "Standing Scapular Clock Drills (No Weight)",
+        "phase": "TAPER",
+        "notes": "Maintenance mode"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Blindfolded Wrist Position Matching",
+        "phase": "GPP",
+        "notes": "5 positions"
+      },
+      {
+        "name": "Reaction Ball Catch Variations",
+        "phase": "GPP",
+        "notes": "Basic catches"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Blindfolded Wrist Position Matching",
+        "phase": "SPP",
+        "notes": "Add partner-guided corrections"
+      },
+      {
+        "name": "Reaction Ball Catch Variations",
+        "phase": "SPP",
+        "notes": "Off-angle rebounds"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Reverse Wrist Curl Holds (Palms Down)",
+        "phase": "GPP",
+        "notes": "10s mid-range"
+      },
+      {
+        "name": "Finger Tip Push-Up Holds",
+        "phase": "GPP",
+        "notes": "Kneeling position"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reverse Wrist Curl Holds (Palms Down)",
+        "phase": "SPP",
+        "notes": "Add finger splay pulses"
+      },
+      {
+        "name": "Finger Tip Push-Up Holds",
+        "phase": "SPP",
+        "notes": "Full plank"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Grip Isometrics (Partner Tug)",
+        "phase": "SPP",
+        "notes": "Simulate gi/clinch retention"
+      },
+      {
+        "name": "Wrist Locks Escape Drills (50% Resistance)",
+        "phase": "SPP",
+        "notes": "Controlled ROM under load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Wrist Flicks",
+        "phase": "GPP",
+        "notes": "Low tension"
+      },
+      {
+        "name": "Sledgehammer Tire Strikes (Over/Under)",
+        "phase": "GPP",
+        "notes": "Light hammer"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Band-Resisted Wrist Flicks",
+        "phase": "SPP",
+        "notes": "Mimic jab recoil"
+      },
+      {
+        "name": "Sledgehammer Tire Strikes (Over/Under)",
+        "phase": "SPP",
+        "notes": "Combat-specific angles"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "CBD Topical Application + Circular Massage",
+        "phase": "TAPER",
+        "notes": "Fight week inflammation control"
+      },
+      {
+        "name": "Wrist Traction with Flexion Hang",
+        "phase": "TAPER",
+        "notes": "Passive decompression"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "High Guard Isometric Holds (With Band)",
+        "phase": "GPP",
+        "notes": "15s holds"
+      },
+      {
+        "name": "Phantom Block Drills (Slow Motion)",
+        "phase": "GPP",
+        "notes": "Technique"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "High Guard Isometric Holds (With Band)",
+        "phase": "SPP",
+        "notes": "Add head movement"
+      },
+      {
+        "name": "Phantom Block Drills (Slow Motion)",
+        "phase": "SPP",
+        "notes": "Impact prep"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Stick/Grip Defense Drills",
+        "phase": "SPP",
+        "notes": "Rotational resistance training"
+      },
+      {
+        "name": "Wrist Wrap Escapes (Against Band)",
+        "phase": "SPP",
+        "notes": "Simulate underhook counters"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Timed Grip Endurance (Various Objects)",
+        "phase": "GPP",
+        "notes": "30s intervals"
+      },
+      {
+        "name": "Water Bottle Shake Drills",
+        "phase": "GPP",
+        "notes": "Light load"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Timed Grip Endurance (Various Objects)",
+        "phase": "SPP",
+        "notes": "Unpredictable releases"
+      },
+      {
+        "name": "Water Bottle Shake Drills",
+        "phase": "SPP",
+        "notes": "Max speed intervals"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist Circles + Neck Rotations",
+        "phase": "SPP",
+        "notes": "Integrate defensive postures"
+      },
+      {
+        "name": "Elbow Strike Shadowing with Wrist Weights",
+        "phase": "SPP",
+        "notes": "Chain kinetic energy"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Rope Dart Wrist Flicks",
+        "phase": "GPP",
+        "notes": "Light implement"
+      },
+      {
+        "name": "Nunchaku Basic Twirls",
+        "phase": "GPP",
+        "notes": "Slow rotations"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Rope Dart Wrist Flicks",
+        "phase": "SPP",
+        "notes": "Add footwork"
+      },
+      {
+        "name": "Nunchaku Basic Twirls",
+        "phase": "SPP",
+        "notes": "Speed transitions"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Pulse Oximeter Biofeedback Drills",
+        "phase": "TAPER",
+        "notes": "Ensure circulation pre-fight"
+      },
+      {
+        "name": "Wrist Vibration Therapy (20Hz)",
+        "phase": "TAPER",
+        "notes": "Neurological priming"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Post-Impact Ice Cup Massage",
+        "phase": "GPP",
+        "notes": "Acute swelling"
+      },
+      {
+        "name": "Lymphatic Drainage Strokes",
+        "phase": "GPP",
+        "notes": "Post-fight"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Post-Impact Ice Cup Massage",
+        "phase": "TAPER",
+        "notes": "Prevent stiffness"
+      },
+      {
+        "name": "Lymphatic Drainage Strokes",
+        "phase": "TAPER",
+        "notes": "Maintenance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Walkouts (Wall Crawls)",
+        "phase": "GPP",
+        "notes": "Controlled loading"
+      },
+      {
+        "name": "Putty Squeeze with Radial Deviation",
+        "phase": "GPP",
+        "notes": "Isolated strength"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Walkouts (Wall Crawls)",
+        "phase": "SPP",
+        "notes": "Add wrist oscillations"
+      },
+      {
+        "name": "Putty Squeeze with Radial Deviation",
+        "phase": "SPP",
+        "notes": "Dynamic presses"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Laser Pointer Targeting Drills",
+        "phase": "SPP",
+        "notes": "Precision under fatigue"
+      },
+      {
+        "name": "Reactive Pad Tapping (Auditory Cues)",
+        "phase": "SPP",
+        "notes": "Improve neural response"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Baoding Ball Rotations",
+        "phase": "GPP",
+        "notes": "Start with 2 balls"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Qigong Wrist Waves",
+        "phase": "TAPER",
+        "notes": "Pre-fight energy flow"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Wrist CARs (Controlled Articular Rotations)",
+        "phase": "GPP",
+        "notes": "Daily ROM maintenance"
+      },
+      {
+        "name": "Prayer Stretch with Radial Deviation",
+        "phase": "GPP",
+        "notes": "30s holds"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Wrist CARs (Controlled Articular Rotations)",
+        "phase": "SPP",
+        "notes": "Add light resistance"
+      },
+      {
+        "name": "Prayer Stretch with Radial Deviation",
+        "phase": "SPP",
+        "notes": "Add active contractions"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Towel Wringing (Water Weight)",
+        "phase": "GPP",
+        "notes": "30s intervals"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "GPP",
+        "notes": "Balance flexors/extensors"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Towel Wringing (Water Weight)",
+        "phase": "SPP",
+        "notes": "Add wrist oscillations"
+      },
+      {
+        "name": "Rice Bucket Finger Extensions",
+        "phase": "SPP",
+        "notes": "Speed drills"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "GPP",
+        "notes": "Light load"
+      },
+      {
+        "name": "Band-Resisted Wrist Bracing",
+        "phase": "GPP",
+        "notes": "Isometric holds"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Eccentric Wrist Curls (3s Lowering)",
+        "phase": "SPP",
+        "notes": "Mimic glove impact angles"
+      },
+      {
+        "name": "Band-Resisted Wrist Bracing",
+        "phase": "SPP",
+        "notes": "Sudden tension releases"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Dowel Rotational Drills (Hammer Grip)",
+        "phase": "GPP",
+        "notes": "Slow rotations"
+      },
+      {
+        "name": "Weighted Rope Whips (Light)",
+        "phase": "GPP",
+        "notes": "Tendon conditioning"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Dowel Rotational Drills (Hammer Grip)",
+        "phase": "SPP",
+        "notes": "Add unpredictable pulls"
+      },
+      {
+        "name": "Weighted Rope Whips (Light)",
+        "phase": "SPP",
+        "notes": "Increase whip speed"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Paraffin Wax Therapy",
+        "phase": "TAPER",
+        "notes": "Pre-fight joint lubrication"
+      },
+      {
+        "name": "Kinesiology Tape Wrist Spider",
+        "phase": "TAPER",
+        "notes": "Proprioceptive cueing during competition"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Median Nerve Flossing",
+        "phase": "GPP",
+        "notes": "2x/day"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners",
+        "phase": "GPP",
+        "notes": "Gentle oscillations"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Median Nerve Flossing",
+        "phase": "SPP",
+        "notes": "Combine with guard positions"
+      },
+      {
+        "name": "Ulnar Nerve Tensioners",
+        "phase": "SPP",
+        "notes": "Add grip component"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "GPP",
+        "notes": "Tendon reloading"
+      },
+      {
+        "name": "Backhand Wall Press Isometrics",
+        "phase": "GPP",
+        "notes": "10s holds"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Reverse Tyler Twist (Flexbar)",
+        "phase": "SPP",
+        "notes": "Eccentric overload"
+      },
+      {
+        "name": "Backhand Wall Press Isometrics",
+        "phase": "SPP",
+        "notes": "Add unstable surface"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up Holds",
+        "phase": "GPP",
+        "notes": "15s plank position"
+      },
+      {
+        "name": "Wrist Walkouts (Wall-Assisted)",
+        "phase": "GPP",
+        "notes": "Controlled loading"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Knuckle Push-Up Holds",
+        "phase": "SPP",
+        "notes": "Add shoulder taps"
+      },
+      {
+        "name": "Wrist Walkouts (Wall-Assisted)",
+        "phase": "SPP",
+        "notes": "Floor progression"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Hook Punch Shadowing with Wrist Weights",
+        "phase": "GPP",
+        "notes": "Light resistance"
+      },
+      {
+        "name": "Grappling Wrist Defense Drills",
+        "phase": "GPP",
+        "notes": "Passive ROM"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Hook Punch Shadowing with Wrist Weights",
+        "phase": "SPP",
+        "notes": "Focus on snapback"
+      },
+      {
+        "name": "Grappling Wrist Defense Drills",
+        "phase": "SPP",
+        "notes": "Add partner resistance"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Contrast Baths (Cold/Hot)",
+        "phase": "GPP",
+        "notes": "Post-training"
+      },
+      {
+        "name": "Compression Wrapping During Sleep",
+        "phase": "GPP",
+        "notes": "Chronic stiffness"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Contrast Baths (Cold/Hot)",
+        "phase": "TAPER",
+        "notes": "Reduce to warm only"
+      },
+      {
+        "name": "Compression Wrapping During Sleep",
+        "phase": "TAPER",
+        "notes": "Discontinue pre-comp"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Side-to-Side Wrist Rocking (Weight Plate)",
+        "phase": "GPP",
+        "notes": "Controlled deviations"
+      },
+      {
+        "name": "Hammer Grip Rotations (Sledgehammer)",
+        "phase": "GPP",
+        "notes": "Light tool"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Side-to-Side Wrist Rocking (Weight Plate)",
+        "phase": "SPP",
+        "notes": "Catch-and-stabilize"
+      },
+      {
+        "name": "Hammer Grip Rotations (Sledgehammer)",
+        "phase": "SPP",
+        "notes": "Heavy implement"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Finger Extension with Wrist Flexion",
+        "phase": "GPP",
+        "notes": "Isolated control"
+      },
+      {
+        "name": "Claw Grip Holds on Rope",
+        "phase": "GPP",
+        "notes": "10s holds"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Finger Extension with Wrist Flexion",
+        "phase": "SPP",
+        "notes": "Dynamic transitions"
+      },
+      {
+        "name": "Claw Grip Holds on Rope",
+        "phase": "SPP",
+        "notes": "Add swinging motions"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "TAPER",
+    "drills": [
+      {
+        "name": "Gentle Wrist Distraction (Partner-Assisted)",
+        "phase": "TAPER",
+        "notes": "Pre-fight joint play"
+      },
+      {
+        "name": "Heat Pack + Passive Flexion/Extension",
+        "phase": "TAPER",
+        "notes": "Maintain ROM without effort"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Focus Mitt Rebound Drills",
+        "phase": "SPP",
+        "notes": "Gradual increase in impact force"
+      },
+      {
+        "name": "Heavy Bag Grazing Strikes",
+        "phase": "SPP",
+        "notes": "Angle-specific loading"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "GPP",
+    "drills": [
+      {
+        "name": "Low-Load BFR Wrist Curls",
+        "phase": "GPP",
+        "notes": "20% 1RM"
+      },
+      {
+        "name": "Vibration Plate Wrist Loading",
+        "phase": "GPP",
+        "notes": "Potential osteogenic stimulus"
+      }
+    ]
+  },
+  {
+    "location": "wrist",
+    "type": "unspecified",
+    "phase_progression": "SPP",
+    "drills": [
+      {
+        "name": "Low-Load BFR Wrist Curls",
+        "phase": "SPP",
+        "notes": "Metabolic stress without heavy impact"
+      },
+      {
+        "name": "Vibration Plate Wrist Loading",
+        "phase": "SPP",
+        "notes": "Reduce frequency"
+      }
+    ]
+  }
+]

--- a/tools/split_rehab_bank.py
+++ b/tools/split_rehab_bank.py
@@ -1,0 +1,66 @@
+import json
+import re
+import sys
+from pathlib import Path
+
+phase_split = re.compile(r"\s*→\s*|\s*,\s*")
+phase_label = re.compile(r"\s*(GPP|SPP|TAPER|PEAK|DELOAD|BASE|UNLISTED)\s*:\s*(.*)")
+
+in_path = Path('data/rehab_bank.json')
+
+with in_path.open() as f:
+    lines = f.readlines()
+
+# remove comment lines that start with '//'
+lines = [ln for ln in lines if not re.match(r'^\s*//', ln)]
+text = ''.join(lines)
+
+try:
+    data = json.loads(text)
+except json.JSONDecodeError as e:
+    sys.stderr.write(f'Failed to parse JSON: {e}\n')
+    sys.exit(1)
+
+out = []
+for obj in data:
+    phases = [p.strip() for p in phase_split.split(obj.get('phase_progression', '')) if p.strip()]
+    if not phases:
+        phases = ['']
+    phase_objs = {ph: {
+        'location': obj['location'],
+        'type': obj['type'],
+        'phase_progression': ph,
+        'drills': []
+    } for ph in phases}
+
+    for drill in obj.get('drills', []):
+        parts = [p.strip() for p in drill.get('notes', '').split('→')]
+        for part in parts:
+            m = phase_label.match(part)
+            if m:
+                phase, note = m.group(1), m.group(2).strip()
+            else:
+                phase = phases[0]
+                note = part
+            entry = {
+                'name': drill['name'],
+                'phase': phase,
+                'notes': note
+            }
+            if phase not in phase_objs:
+                phase_objs[phase] = {
+                    'location': obj['location'],
+                    'type': obj['type'],
+                    'phase_progression': phase,
+                    'drills': []
+                }
+            phase_objs[phase]['drills'].append(entry)
+
+    for ph in phases:
+        out.append(phase_objs[ph])
+
+out_path = Path('data/rehab_bank_split.json')
+with out_path.open('w') as f:
+    json.dump(out, f, indent=2)
+
+print(f"Wrote {len(out)} entries to {out_path}")


### PR DESCRIPTION
## Summary
- add a Python helper script to split multi-phase rehab entries
- generate `rehab_bank_split.json` with one phase per entry using the script

## Testing
- `python3 tools/split_rehab_bank.py`
- `python3 - <<'PY'
import json
with open('data/rehab_bank_split.json') as f:
    data=json.load(f)
print('entries', len(data))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684e82ba2eac832e8801b47010c18a6a