### PR TITLE
Fix duplicate rehab headers

### DIFF
--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -262,7 +262,7 @@ def generate_rehab_protocols(
     if not lines:
         return "\n⚠️ No rehab options for this phase.", seen_drills
 
-    return "\n**Rehab Protocols**\n" + "\n".join(lines), seen_drills
+    return "\n".join(lines), seen_drills
 
 
 def combine_three_phase_drills(location: str, injury_type: str) -> list[dict]:


### PR DESCRIPTION
## Summary
- remove internal **Rehab Protocols** heading from `generate_rehab_protocols`

## Testing
- `python -m py_compile fightcamp/rehab_protocols.py`
- `python -m py_compile fightcamp/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684e19d72388832e969974633ac5967b