### PR TITLE
Fix mental block classification on single word input

### DIFF
--- a/fightcamp/injury_synonyms.py
+++ b/fightcamp/injury_synonyms.py
@@ -453,7 +453,12 @@ def canonicalize_location(text: str, threshold: int = 85) -> str | None:
     """
     text = text.lower()
     for key, canonical in LOCATION_MAP.items():
-        if key in text or fuzz.partial_ratio(key, text) >= threshold:
+        # Prefer exact word matches to avoid false positives like "shin" -> "chin"
+        if re.search(r"\b" + re.escape(key) + r"\b", text):
+            return canonical
+        # Only use fuzzy matching for longer phrases where accidental overlaps
+        # are less likely
+        if len(key) > 4 and fuzz.partial_ratio(key, text) >= threshold:
             return canonical
     return None
 

--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -120,7 +120,7 @@ def classify_mental_block(text: str, top_n: int = 2, threshold: int = 85) -> lis
         return ["generic"]
 
     text = text.lower().strip()
-    if any(bad in text for bad in ["n/a", "none", "idk", "na"]) or len(text.split()) < 2:
+    if any(bad in text for bad in ["n/a", "none", "idk", "na"]):
         return ["generic"]
 
     scores = {}


### PR DESCRIPTION
## Summary
- allow classify_mental_block to process single words like "Confidence"
- prevent "shin" injuries from mapping to jaw due to fuzzy match confusion

## Testing
- `python -m fightcamp.main test_data.json` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684ea20364fc832e9bc48a02d2a791a6