### PR TITLE
Adjust rehab penalty for GPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The generator ranks drills and exercises based on a simple heuristic score. Each
 - Phase tag matches add `+0.4` each
 - Fatigue penalties: `-0.75` (high) or `-0.35` (moderate)
 - Missing required equipment removes the exercise (`-999`)
-- Rehab exercises incur `-0.5` in GPP, `-1.0` in SPP and `-0.75` in TAPER
+  - Rehab exercises incur `-0.7` in GPP, `-1.0` in SPP and `-0.75` in TAPER
 
 **Conditioning module** (`conditioning.py`)
 

--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -103,7 +103,7 @@ def score_exercise(
         return -999
 
     if is_rehab:
-        phase_penalties = {"GPP": -0.5, "SPP": -1.0, "TAPER": -0.75}
+        phase_penalties = {"GPP": -0.7, "SPP": -1.0, "TAPER": -0.75}
         score += phase_penalties.get(current_phase, -0.75)
 
     score += random.uniform(-0.15, 0.15)

--- a/notes/cheat_sheet.md
+++ b/notes/cheat_sheet.md
@@ -100,7 +100,7 @@ Every module looks at how many of its tags match your goals, weaknesses and figh
 - Phase tag match (GPP/SPP/TAPER): **+0.4** each
 - Fatigue penalty: **-0.35** (moderate) or **-0.75** (high)
 - Missing required equipment: exercise is skipped
-- Rehab exercise penalty: **-0.5** in GPP, **-1.0** in SPP, **-0.75** in TAPER
+- Rehab exercise penalty: **-0.7** in GPP, **-1.0** in SPP, **-0.75** in TAPER
 
 ### Conditioning Module
 - Style match (exact): **+1.5**


### PR DESCRIPTION
## Summary
- penalize rehab exercises by `-0.7` in GPP
- document new penalty in README and cheat sheet

## Testing
- `python -m fightcamp.main` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684ea9b93d48832ebf1842b9ef7febb9