### PR TITLE
Fix mental block classifier for 'No' responses

### DIFF
--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -120,7 +120,8 @@ def classify_mental_block(text: str, top_n: int = 2, threshold: int = 85) -> lis
         return ["generic"]
 
     text = text.lower().strip()
-    if any(bad in text for bad in ["n/a", "none", "idk", "na"]):
+    # treat short negative replies as generic
+    if text in {"no", "nope", "nah", "n/a", "none", "na", "idk"}:
         return ["generic"]
 
     scores = {}


### PR DESCRIPTION
## Summary
- treat short negative answers like 'no' or 'nah' as generic
- compile python files for sanity check

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eb754f30c832ebe29669f202dc9ee