### PR TITLE
Fix conditioning bank formats

### DIFF
--- a/data/exercise_bank.json
+++ b/data/exercise_bank.json
@@ -714,8 +714,8 @@
   "type": "unilateral",
   "tags": ["upper_body", "compound"],
   "equipment": "medicine_ball"
-}
-]
+  },
+
   {
     "name": "Incline DB Press",
     "category": "upper_body",

--- a/data/style_conditioning_bank.json
+++ b/data/style_conditioning_bank.json
@@ -8,7 +8,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "concurrent training",
     "duration": "30s max rope slams → 30s dirty boxing combos → x5 rounds",
     "intensity": "95% effort",
@@ -49,7 +49,7 @@
       "GPP",
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "strongman meets fight prep",
     "duration": "30s sandbag bear hug → 10 sprawls → x5 rounds",
     "intensity": "Violent intent",
@@ -89,7 +89,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "infighting simulator",
     "duration": "5 trap bar jumps → 10 push-ups → x6 rounds",
     "intensity": "85% effort",
@@ -128,7 +128,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "suffering",
     "duration": "20m sled push → 10 DB thruster punches → x5 rounds",
     "intensity": "Near-vomit",
@@ -147,7 +147,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "prison rules",
     "duration": "10 burpees → 10 sprawls → 10 jumping knees → x5 rounds",
     "intensity": "Survival mode",
@@ -166,7 +166,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "neck torture",
     "duration": "10min continuous: 5 neck bridges → 5 plate neck rotations",
     "intensity": "Steady burn",
@@ -186,7 +186,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "punishment",
     "duration": "30s max hooks → 10 push-ups → 30s uppercuts → x5 rounds",
     "intensity": "Fight night pace",
@@ -246,7 +246,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "retreat punishment",
     "duration": "20 KB swings → 10 backward lunges → x6 rounds",
     "intensity": "Controlled rage",
@@ -266,7 +266,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch hell",
     "duration": "30s sandbag carry → 10 knees → 5 sprawls → x5 rounds",
     "intensity": "90% effort",
@@ -286,7 +286,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "relentless pressure",
     "duration": "10 trap bar deadlifts → 20m farmer walk → x6 rounds",
     "intensity": "75% 1RM",
@@ -305,7 +305,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pure suffering",
     "duration": "30s sprint → 10 burpees → 30s shadowboxing → x5 rounds",
     "intensity": "Near death",
@@ -345,7 +345,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "footwork torture",
     "duration": "20m sled drag (backward) → 10 defensive slips → x6 rounds",
     "intensity": "75% effort",
@@ -385,7 +385,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "surprise attack",
     "duration": "5 band-resisted sprints → 10 sprawls → x8 rounds",
     "intensity": "90% effort",
@@ -405,7 +405,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "old school",
     "duration": "10min continuous: 5 power cleans → 5 push-ups",
     "intensity": "60% 1RM",
@@ -425,7 +425,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "doorway defense",
     "duration": "10 KB swings → 5 wall sit punches → x6 rounds",
     "intensity": "90% effort",
@@ -444,7 +444,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "no escape",
     "duration": "30s sprint → 10 push presses (imaginary opponent) → x8 rounds",
     "intensity": "100% effort",
@@ -463,7 +463,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "prehab",
     "duration": "15min continuous: 5 neck nods → 5 neck rotations",
     "intensity": "Steady",
@@ -483,7 +483,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "asphalt conditioning",
     "duration": "5 tire flips → 10 push-ups → 5 burpees → x6 rounds",
     "intensity": "90% effort",
@@ -503,7 +503,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "cage wrestler",
     "duration": "20m sled push → 10 KB swings → x5 rounds",
     "intensity": "90% effort",
@@ -523,7 +523,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "rotational destruction",
     "duration": "30s alternating hammer strikes → 30s tire flips → x5 rounds",
     "intensity": "Max effort",
@@ -542,7 +542,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "dirty grappler",
     "duration": "30s bear hug carry → 10 knees → x6 rounds",
     "intensity": "Violent intent",
@@ -581,7 +581,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "wall fighting",
     "duration": "20 KB cleans → 10 wall knee strikes → x5 rounds",
     "intensity": "85% effort",
@@ -601,7 +601,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "throws under fatigue",
     "duration": "5 bag tosses → 5 tire flips → x6 rounds",
     "intensity": "90% effort",
@@ -620,7 +620,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "ground survival",
     "duration": "30s forearm plank → 5 technical stand-ups → x8 rounds",
     "intensity": "Burnout",
@@ -660,7 +660,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "striking from clinch",
     "duration": "15 slam ball → 10 wall push-offs → x6 rounds",
     "intensity": "90% effort",
@@ -680,7 +680,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "last-man-standing",
     "duration": "20m sled drag → 5 bag slams → x5 rounds",
     "intensity": "Near-vomit",
@@ -700,7 +700,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "full-body violence",
     "duration": "10 hammer strikes → 5 tire jumps → x8 rounds",
     "intensity": "Kill switch",
@@ -739,7 +739,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "takedown defense",
     "duration": "10 sprawls → 10 knees → x8 rounds",
     "intensity": "90% effort",
@@ -759,7 +759,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "ground transitions",
     "duration": "10 KB swings → 5 bag-to-shoulder → x6 rounds",
     "intensity": "85% effort",
@@ -771,25 +771,6 @@
     "equipment_note": "24kg KB, 70lb sandbag"
   },
   {
-    "name": "Knuckle Dragger",
-    "equipment": [
-      "Barbell"
-    ],
-    "phases": [
-      "GPP"
-    ],
-    "system": "Aerobic",
-    "modality": "old school brutality",
-    "duration": "10min: 5 cleans → 5 push presses → 5 squats",
-    "intensity": "60% 1RM",
-    "tags": [
-      "brawler",
-      "mma"
-    ],
-    "notes": "Golden era catch wrestler conditioning",
-    "equipment_note": "95lb barbell, no gloves"
-  },
-  {
     "name": "Headbutt Conditioning",
     "equipment": [
       "Neck Harness"
@@ -797,7 +778,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "forbidden weapons",
     "duration": "15min: 5 neck bridges → 5 plate nods",
     "intensity": "Steady burn",
@@ -817,7 +798,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch striking",
     "duration": "10 DB uppercuts → 5 med ball slams → x6 rounds",
     "intensity": "90% power",
@@ -857,7 +838,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "survival conditioning",
     "duration": "30s bag carry → 10 KB snatches → x5 rounds",
     "intensity": "95% effort",
@@ -876,7 +857,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "no-rules endurance",
     "duration": "30s sprint → 10 sprawls → 10 knees → x5 rounds",
     "intensity": "Near-death",
@@ -895,7 +876,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "isometric endurance",
     "duration": "30s clinch hold → 10 knees → x5 rounds",
     "intensity": "90% effort",
@@ -915,7 +896,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "rotational endurance",
     "duration": "20 med ball slams → 10 short uppercuts → x5 rounds",
     "intensity": "85% effort",
@@ -936,7 +917,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "resisted pressure",
     "duration": "30s band-resisted forward pressure → 10 cage knees → x5 rounds",
     "intensity": "90% effort",
@@ -955,7 +936,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "dynamic endurance",
     "duration": "20 KB swings → 10 plumb knees → x5 rounds",
     "intensity": "85% effort",
@@ -975,7 +956,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "upper body clinch",
     "duration": "30s pummeling drills → 10 bodylock lifts → x5 rounds",
     "intensity": "85% effort",
@@ -995,7 +976,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive endurance",
     "duration": "30s rope clinch (simulated) → 10 short hooks → x5 rounds",
     "intensity": "90% effort",
@@ -1014,7 +995,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "striking endurance",
     "duration": "30s max knees → 10 sprawls → x5 rounds",
     "intensity": "95% effort",
@@ -1035,7 +1016,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "cage simulation",
     "duration": "30s wall pressure → 10 short elbows → x5 rounds",
     "intensity": "90% effort",
@@ -1055,7 +1036,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "takedown defense",
     "duration": "30s grip fighting → 5 hip toss counters → x5 rounds",
     "intensity": "85% effort",
@@ -1075,7 +1056,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "resisted knees",
     "duration": "20 band-resisted knees → 10 switch knees → x5 rounds",
     "intensity": "90% effort",
@@ -1095,7 +1076,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "neck endurance",
     "duration": "15min continuous: 30s forward resistance → 30s lateral → 30s rear",
     "intensity": "70% effort",
@@ -1114,7 +1095,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "power endurance",
     "duration": "10 KB snatches → 10 sprawls → x5 rounds",
     "intensity": "90% effort",
@@ -1133,7 +1114,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "combo endurance",
     "duration": "30s clinch knees → 30s short punches → x5 rounds",
     "intensity": "90% effort",
@@ -1153,7 +1134,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "forward pressure",
     "duration": "20m sled push → 10 cage knees → x5 rounds",
     "intensity": "85% effort",
@@ -1192,7 +1173,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive transitions",
     "duration": "30s clinch → 5 sprawls → x8 rounds",
     "intensity": "90% effort",
@@ -1212,7 +1193,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "isometric endurance",
     "duration": "15min continuous: 30s forward resistance → 30s lateral → 30s rear",
     "intensity": "70% effort",
@@ -1233,7 +1214,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "resisted strikes",
     "duration": "20 band-resisted knees → 10 switch knees → x5 rounds",
     "intensity": "90% effort",
@@ -1254,7 +1235,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "loaded endurance",
     "duration": "30s sandbag carry → 10 knees → x5 rounds",
     "intensity": "85% effort",
@@ -1275,7 +1256,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "short-range power",
     "duration": "30s elbow combinations → 10 clinch knees → x5 rounds",
     "intensity": "90% effort",
@@ -1295,7 +1276,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive striking",
     "duration": "30s defend collar tie → 10 counter uppercuts → x5 rounds",
     "intensity": "85% effort",
@@ -1315,7 +1296,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pure endurance",
     "duration": "5min continuous: clinch pummeling → knees → short punches",
     "intensity": "80% effort",
@@ -1336,7 +1317,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive endurance",
     "duration": "30s band-resisted whizzers → 5 sprawls → x5 rounds",
     "intensity": "90% effort",
@@ -1396,7 +1377,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pivot counters",
     "duration": "30s band-resisted pivots → 30s check hooks, 6 rounds",
     "intensity": "85% power",
@@ -1436,7 +1417,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "shoulder endurance",
     "duration": "1min band-resisted shoulder rolls, 30s counters x 6",
     "intensity": "80% effort",
@@ -1475,7 +1456,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "duck counters",
     "duration": "20 roll-under uppercuts, 10 body shots x 5 rounds",
     "intensity": "85% power",
@@ -1495,7 +1476,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "stop-hit training",
     "duration": "3min rounds: intercepting jabs, 1min rest x 4",
     "intensity": "90% timing focus",
@@ -1535,7 +1516,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "lean-back counters",
     "duration": "50 pull-back straights, 5 rounds",
     "intensity": "90% accuracy",
@@ -1554,7 +1535,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "framing counters",
     "duration": "30s frame-and-strike, 30s rest x 8",
     "intensity": "85% effort",
@@ -1594,7 +1575,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "exhausted counters",
     "duration": "30s max punches → 30s counter-only, 6 rounds",
     "intensity": "90% effort",
@@ -1614,7 +1595,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive angles",
     "duration": "3min rounds: slip → pivot → counter, 1min rest x 4",
     "intensity": "85% effort",
@@ -1653,7 +1634,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch counters",
     "duration": "3min rounds: catch → knee, 1min rest x 5",
     "intensity": "85% power",
@@ -1693,7 +1674,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch defense",
     "duration": "30s frame under pressure, 30s counter knees x 6",
     "intensity": "85% effort",
@@ -1733,7 +1714,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pivot power",
     "duration": "20 check hooks per side, 5 rounds",
     "intensity": "90% rotation",
@@ -1773,7 +1754,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "footwork",
     "duration": "3min work, 1min rest x 5 rounds",
     "intensity": "80% effort",
@@ -1794,7 +1775,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "resisted footwork",
     "duration": "30s lateral steps, 30s rest x 8 rounds",
     "intensity": "70-80% effort",
@@ -1836,7 +1817,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "angle striking",
     "duration": "3min rounds: 45° cuts after combos, 1min rest x 4",
     "intensity": "85% effort",
@@ -1877,7 +1858,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "precision endurance",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "Fast twitch focus",
@@ -1897,7 +1878,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "footwork + stamina",
     "duration": "30s ropes + 30s cone drills, 8 rounds",
     "intensity": "85% effort",
@@ -1917,7 +1898,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive backpedaling",
     "duration": "20m sled drags backward, 6 rounds",
     "intensity": "50% bodyweight load",
@@ -1957,7 +1938,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "shoulder endurance",
     "duration": "1min band-resisted jabs, 30s rest x 6",
     "intensity": "80% effort",
@@ -1997,7 +1978,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "cage cutting",
     "duration": "3min rounds, 1min rest x 4",
     "intensity": "70% effort",
@@ -2017,7 +1998,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "push kick defense",
     "duration": "20 resisted backsteps, 10 teep counters, 5 rounds",
     "intensity": "80% effort",
@@ -2037,7 +2018,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "shoulder stamina",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "Fast twitch focus",
@@ -2057,7 +2038,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "slip-counter",
     "duration": "3min rounds: slip right → cross, 1min rest x 4",
     "intensity": "85% power",
@@ -2097,7 +2078,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "step-in striking",
     "duration": "10 band-resisted step jabs, 5 rounds",
     "intensity": "80% speed",
@@ -2116,7 +2097,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "unpredictability",
     "duration": "3min rounds: random direction changes, 1min rest x 4",
     "intensity": "70% effort",
@@ -2137,7 +2118,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "exhausted precision",
     "duration": "30s max-speed punches → 30s defensive slides, 6 rounds",
     "intensity": "90% effort",
@@ -2157,7 +2138,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "endurance",
     "duration": "30s hangs, 30s rest x 8",
     "intensity": "70% effort",
@@ -2177,7 +2158,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "power endurance",
     "duration": "3min rounds: 10 kicks/leg, 1min rest x 5",
     "intensity": "90% power",
@@ -2220,7 +2201,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "push kick endurance",
     "duration": "15 teeps/min, 3min rounds x 4",
     "intensity": "80% speed",
@@ -2241,7 +2222,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "combination kicking",
     "duration": "3min rounds: jab-cross-low kick, 1min rest x 5",
     "intensity": "85% power",
@@ -2282,7 +2263,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "Muay Thai combinations",
     "duration": "3min rounds: elbow-kick-elbow, 1min rest x 4",
     "intensity": "80% power",
@@ -2304,7 +2285,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "fight-ending kicks",
     "duration": "20 kicks/leg, 30s rest, 5 rounds",
     "intensity": "95% power",
@@ -2344,7 +2325,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "timing under fatigue",
     "duration": "3min rounds: 5 switch kicks → 5 punches, x5",
     "intensity": "85% effort",
@@ -2386,7 +2367,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "liver shot simulation",
     "duration": "20 kicks/round, 5 rounds",
     "intensity": "90% power",
@@ -2406,7 +2387,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "forward pressure",
     "duration": "15 knees/leg, 5 rounds",
     "intensity": "85% power",
@@ -2446,7 +2427,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive kicking",
     "duration": "20 counters/min, 5 rounds",
     "intensity": "Fast retraction",
@@ -2486,7 +2467,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "muay thai clinch",
     "duration": "3min rounds: 10 knees/position, x5",
     "intensity": "85% power",
@@ -2506,7 +2487,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "stance flexibility",
     "duration": "20 stance switches → 5 kicks, 5 rounds",
     "intensity": "Fast transitions",
@@ -2567,7 +2548,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "linear power",
     "duration": "20 kicks/leg, 5 rounds",
     "intensity": "90% extension",
@@ -2607,7 +2588,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "feint kicking",
     "duration": "3min rounds: fake low → high kick, x5",
     "intensity": "85% speed",
@@ -2648,7 +2629,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "range transition",
     "duration": "20 teeps → 10 knees, 5 rounds",
     "intensity": "80% speed",
@@ -2690,7 +2671,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "circuit",
     "duration": "3min work, 1min rest x 3-5 rounds",
     "intensity": "85-90% effort",
@@ -2731,7 +2712,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "footwork + sprint",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "90% sprint effort",
@@ -2751,7 +2732,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "strongman + sprawl",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "Heavy sandbag, explosive KB",
@@ -2771,7 +2752,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "rotational power",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "Max power rotations",
@@ -2791,7 +2772,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "concurrent training",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "90% effort",
@@ -2831,7 +2812,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "power endurance",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "85-90% effort",
@@ -2873,7 +2854,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "full-system fatigue",
     "duration": "3min work, 1min rest x 3 rounds",
     "intensity": "90-95% effort",
@@ -2893,7 +2874,7 @@
       "GPP",
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "loaded carry",
     "duration": "30s work, 30s rest x 5 rounds",
     "intensity": "85% max load",
@@ -2932,7 +2913,7 @@
       "GPP",
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "strongman",
     "duration": "10 flips + 10 sprawls, 3 rounds",
     "intensity": "Max speed flips",
@@ -2952,7 +2933,7 @@
       "GPP",
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "loaded drag",
     "duration": "40m forward/backward x 4 trips",
     "intensity": "50-70% bodyweight",
@@ -2992,7 +2973,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "concurrent training",
     "duration": "30s ropes + 30s bag, 5 rounds",
     "intensity": "90% effort",
@@ -3011,7 +2992,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "eccentric loading",
     "duration": "5 jumps + 5 deadlifts, 4 rounds",
     "intensity": "60% 1RM",
@@ -3030,7 +3011,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "complex",
     "duration": "8 rounds: 5 presses + 5 squats",
     "intensity": "50% 1RM",
@@ -3069,7 +3050,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pushing",
     "duration": "20m push + 10 sprawls, 6 rounds",
     "intensity": "Bodyweight load",
@@ -3088,7 +3069,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "strongman endurance",
     "duration": "30s bear hug carry → 10 knees, 5 rounds",
     "intensity": "90% effort",
@@ -3108,7 +3089,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "forward pressure",
     "duration": "20m sled push → 5 sprawls, 6 rounds",
     "intensity": "Bodyweight load",
@@ -3148,7 +3129,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "loaded carries",
     "duration": "30s walk → 10 uppercuts, 5 rounds",
     "intensity": "85% max load",
@@ -3167,7 +3148,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "forward knee drive",
     "duration": "20 KB swings → 10 marching knees, 5 rounds",
     "intensity": "Violent intent",
@@ -3186,7 +3167,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "infighting",
     "duration": "30s flurry punches → 10 collar tie knees, 5 rounds",
     "intensity": "95% effort",
@@ -3226,7 +3207,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "resisted pressure",
     "duration": "30s band-resisted forward steps → 10 sprawls, 6 rounds",
     "intensity": "85% effort",
@@ -3246,7 +3227,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch endurance",
     "duration": "30s double-collar tie → 20 knees, 5 rounds",
     "intensity": "90% effort",
@@ -3266,7 +3247,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "strongman MMA",
     "duration": "10 sandbag cleans → 10 KB snatches, 5 rounds",
     "intensity": "Heavy",
@@ -3305,7 +3286,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "relentless pace",
     "duration": "10 sprawls → 10 burpee jumps, 6 rounds",
     "intensity": "No rest",
@@ -3325,7 +3306,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "suffering",
     "duration": "20m sled push → 10 band-resisted punches, 5 rounds",
     "intensity": "Near-vomit",
@@ -3364,7 +3345,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "plum control",
     "duration": "20 KB swings → 10 clinch knees, 5 rounds",
     "intensity": "90% effort",
@@ -3384,7 +3365,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "grapple-strike",
     "duration": "10 band-resisted level changes → 10 med ball slams, 5 rounds",
     "intensity": "85% effort",
@@ -3403,7 +3384,7 @@
     "phases": [
       "GPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "clinch endurance",
     "duration": "30s shoulder carry → 10 sprawls, 6 rounds",
     "intensity": "70lb+ sandbag",
@@ -3445,7 +3426,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "killing pace",
     "duration": "20 alternating hammer strikes → 5 burpees over tire, 5 rounds",
     "intensity": "100% effort",
@@ -3466,7 +3447,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "hell circuit",
     "duration": "30s sandbag carry → 10 KB swings → 10 band-resisted knees, 5 rounds",
     "intensity": "No breaks",
@@ -3509,7 +3490,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive scrambling",
     "duration": "10 sprawl → spin sequences, 5 rounds",
     "intensity": "Max speed",
@@ -3530,7 +3511,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "wall scrambling",
     "duration": "3min rounds, 1min rest x 4",
     "intensity": "Fight pace",
@@ -3570,7 +3551,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "failed shot recovery",
     "duration": "15 shot → roll sequences, 5 rounds",
     "intensity": "85% effort",
@@ -3611,7 +3592,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "transitional awareness",
     "duration": "10 sub attempts → 5 sweeps, 5 rounds",
     "intensity": "Fast transitions",
@@ -3631,7 +3612,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "live clinch work",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "90% effort",
@@ -3673,7 +3654,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "mixed reactions",
     "duration": "3min rounds: 1-2 → shot, 1min rest x 4",
     "intensity": "85% speed",
@@ -3714,7 +3695,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "defensive urgency",
     "duration": "15 escapes → 5 shots, 5 rounds",
     "intensity": "90% effort",
@@ -3735,7 +3716,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "cage IQ",
     "duration": "3min rounds, 1min rest x 4",
     "intensity": "Fight pace",
@@ -3777,7 +3758,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "hybrid transitions",
     "duration": "3min rounds: combo → shot → sub attempt, 1min rest x 4",
     "intensity": "85% effort",
@@ -3817,7 +3798,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "aerial transitions",
     "duration": "10 flying armbar attempts, 5 rounds",
     "intensity": "Technical",
@@ -3837,7 +3818,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "muay thai scrambles",
     "duration": "20 clinch spins, 5 rounds",
     "intensity": "Fast pivots",
@@ -3877,7 +3858,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "live reaction",
     "duration": "10 standing backtakes, 5 rounds",
     "intensity": "85% control",
@@ -3898,7 +3879,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "transition chains",
     "duration": "3min rounds, 1min rest x 5",
     "intensity": "85% effort",
@@ -3940,7 +3921,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "isolated attacks",
     "duration": "20 armbar snaps/min, 4 rounds",
     "intensity": "Explosive extensions",
@@ -3982,7 +3963,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "fatigue finishing",
     "duration": "10 standing guillotines, 3min rounds",
     "intensity": "80% squeeze",
@@ -4002,7 +3983,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "back control",
     "duration": "5 twister setups → 3 finishes, 5 rounds",
     "intensity": "Slow, technical",
@@ -4043,7 +4024,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "sinking mechanics",
     "duration": "15 sprawl → D’Arce entries, 5 rounds",
     "intensity": "Explosive shots",
@@ -4084,7 +4065,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "grip endurance",
     "duration": "3min rounds: 5 chokes/min, 1min rest x 4",
     "intensity": "90% grip",
@@ -4124,7 +4105,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "pressure finish",
     "duration": "10 squeezes @ 10sec, 5 rounds",
     "intensity": "85% effort",
@@ -4165,7 +4146,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "flexibility + finish",
     "duration": "10 shin-to-throat setups, 5 rounds",
     "intensity": "Slow, controlled",
@@ -4205,7 +4186,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "hip pressure",
     "duration": "10 sweeps → 3 finishes, 5 rounds",
     "intensity": "Explosive hips",
@@ -4246,7 +4227,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "grip fighting",
     "duration": "20 collar grips → 10 finishes, 4 rounds",
     "intensity": "80% speed",
@@ -4286,7 +4267,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "sleeve control",
     "duration": "20 no-gi finishes, 5 rounds",
     "intensity": "90% squeeze",
@@ -4326,7 +4307,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "control transitions",
     "duration": "3min rounds: arm trap → choke, 1min rest x 4",
     "intensity": "85% control",
@@ -4366,7 +4347,7 @@
     "phases": [
       "SPP"
     ],
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "modality": "shoulder pressure",
     "duration": "10 entries → 5 finishes, 5 rounds",
     "intensity": "Slow grind",
@@ -4401,7 +4382,7 @@
   {
     "name": "Clinch Knee Storm Intervals",
     "equipment": ["clinching dummy", "wall"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "45s on / 60s off",
@@ -4413,7 +4394,7 @@
   {
     "name": "Forward-Blast Heavy Bag Intervals",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "20s on / 40s off",
@@ -4425,7 +4406,7 @@
   {
     "name": "Wall-Wrestler Pummel Rounds",
     "equipment": ["wall", "mma gloves"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "30s on / 45s off",
@@ -4437,7 +4418,7 @@
   {
     "name": "Switch-Kick Endurance Drill",
     "equipment": ["thai pads"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "40s on / 50s off",
@@ -4449,7 +4430,7 @@
   {
     "name": "Brawler's Body Shot Barrage",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "25s on / 35s off",
@@ -4461,7 +4442,7 @@
   {
     "name": "Clinch-to-Strike Transition Drill",
     "equipment": ["partner", "focus mitts"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "45s on / 60s off",
@@ -4473,7 +4454,7 @@
   {
     "name": "Sprawl-to-Strike Intervals",
     "equipment": ["mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "30s on / 45s off",
@@ -4485,7 +4466,7 @@
   {
     "name": "Counter Striker's Shell Defense Drill",
     "equipment": ["partner", "focus mitts"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "1min on / 1min off",
@@ -4497,7 +4478,7 @@
   {
     "name": "Submission Chain Fatigue Drill",
     "equipment": ["grappler dummy"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "40s on / 50s off",
@@ -4509,7 +4490,7 @@
   {
     "name": "Teep-and-Clinch Gauntlet",
     "equipment": ["partner", "thai pads"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "glycolytic",
     "modality": "interval",
     "duration": "45s on / 60s off",
@@ -4522,8 +4503,8 @@
   {
     "name": "Sprawl-to-Takedown Reaction Drill",
     "equipment": ["partner", "mat"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "sprint",
     "duration": "5s effort / 55s rest",
     "intensity": "max",
@@ -4534,8 +4515,8 @@
   {
     "name": "Lateral Escape Plyo Pushoffs",
     "equipment": ["plyo box"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "jump",
     "duration": "8x per side / 60s rest",
     "intensity": "max",
@@ -4546,8 +4527,8 @@
   {
     "name": "Guillotine Shot Sprints",
     "equipment": ["open space"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "sprint",
     "duration": "10s max effort / 50s rest",
     "intensity": "max",
@@ -4558,8 +4539,8 @@
   {
     "name": "Switch-Kick Power Bursts",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x per leg / 60s rest",
     "intensity": "max",
@@ -4570,8 +4551,8 @@
   {
     "name": "Takedown Shot Reaction Drill",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "5s effort / 55s rest",
     "intensity": "max",
@@ -4582,8 +4563,8 @@
   {
     "name": "Cross-Counter Plyo Pushups",
     "equipment": ["plyo box"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "jump",
     "duration": "6x per side / 60s rest",
     "intensity": "max",
@@ -4594,8 +4575,8 @@
   {
     "name": "Thai Plum Explosion Drill",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "isometric",
     "duration": "5s max pull / 55s rest",
     "intensity": "max",
@@ -4606,8 +4587,8 @@
   {
     "name": "Sprawl-to-Shot Sprints",
     "equipment": ["mat"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "sprint",
     "duration": "8s max / 52s rest",
     "intensity": "max",
@@ -4618,8 +4599,8 @@
   {
     "name": "Lateral Plyo Pushoffs",
     "equipment": ["plyo box"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "jump",
     "duration": "6x per side / 60s rest",
     "intensity": "max",
@@ -4630,8 +4611,8 @@
   {
     "name": "Neck Snap Drill",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "isometric",
     "duration": "5s max effort / 55s rest",
     "intensity": "max",
@@ -4642,8 +4623,8 @@
   {
     "name": "Switch-Kick Acceleration",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "10x per leg / 60s rest",
     "intensity": "max",
@@ -4654,8 +4635,8 @@
   {
     "name": "Overhand Right Bursts",
     "equipment": ["focus mitts"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x per side / 60s rest",
     "intensity": "max",
@@ -4666,8 +4647,8 @@
   {
     "name": "Blast Double Sprints",
     "equipment": ["open space"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "sprint",
     "duration": "10m sprints / 50s rest",
     "intensity": "max",
@@ -4678,8 +4659,8 @@
   {
     "name": "Knee Strike Bursts",
     "equipment": ["clinching dummy"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "5x per leg / 60s rest",
     "intensity": "max",
@@ -4690,8 +4671,8 @@
   {
     "name": "Guillotine Shot Reactions",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "5s effort / 55s rest",
     "intensity": "max",
@@ -4700,22 +4681,10 @@
     "equipment_note": "Grass or mat surface only."
   },
   {
-    "name": "Cross-Counter Plyo Pushups",
-    "equipment": ["plyo box"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
-    "modality": "jump",
-    "duration": "8x / 60s rest",
-    "intensity": "max",
-    "tags": ["boxing", "counter_striker", "pressure_fighter"],
-    "notes": "Explode up to simulate weight transfer for cross counters.",
-    "equipment_note": "Hands on 12-inch box."
-  },
-  {
     "name": "MT Teep Acceleration Drill",
     "equipment": ["thai pads"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "10x per leg / 60s rest",
     "intensity": "max",
@@ -4726,8 +4695,8 @@
   {
     "name": "Reactive Sprawl Jumps",
     "equipment": ["mat"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "jump",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4738,8 +4707,8 @@
   {
     "name": "Forward Lunge Strikes",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4750,8 +4719,8 @@
   {
     "name": "Takedown-to-Knee Drill",
     "equipment": ["takedown dummy"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "compound",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4762,8 +4731,8 @@
   {
     "name": "Switch-Kick Plyos",
     "equipment": ["plyo box"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "jump",
     "duration": "6x per side / 60s rest",
     "intensity": "max",
@@ -4774,8 +4743,8 @@
   {
     "name": "BJJ Explosive Guard Pull",
     "equipment": ["mat"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4786,8 +4755,8 @@
   {
     "name": "Dump Explosions",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "throw",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4798,8 +4767,8 @@
   {
     "name": "Slip-Counter Springs",
     "equipment": ["double-end bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4810,8 +4779,8 @@
   {
     "name": "Cage-Push Escapes",
     "equipment": ["cage"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "isometric",
     "duration": "5s max / 55s rest",
     "intensity": "max",
@@ -4822,8 +4791,8 @@
   {
     "name": "Liver Hook Bursts",
     "equipment": ["body opponent bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4834,8 +4803,8 @@
   {
     "name": "Long Guard Snap",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4846,8 +4815,8 @@
   {
     "name": "Reshot Chains",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "compound",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4858,8 +4827,8 @@
   {
     "name": "Axe Kick Acceleration",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4870,8 +4839,8 @@
   {
     "name": "Swarm Entry Sprints",
     "equipment": ["open space"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "sprint",
     "duration": "10m / 50s rest",
     "intensity": "max",
@@ -4882,8 +4851,8 @@
   {
     "name": "Strike-to-Clinch Drill",
     "equipment": ["focus mitts"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "compound",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4894,8 +4863,8 @@
   {
     "name": "Hip Slam Drill",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "throw",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4906,8 +4875,8 @@
   {
     "name": "Pull-Counter Springs",
     "equipment": ["slip bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "reactive",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4918,8 +4887,8 @@
   {
     "name": "Ground-and-Pound Bursts",
     "equipment": ["grappler dummy"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "10s max / 50s rest",
     "intensity": "max",
@@ -4930,8 +4899,8 @@
   {
     "name": "Corner Knee Bursts",
     "equipment": ["heavy bag", "corner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4942,8 +4911,8 @@
   {
     "name": "Scrambler's Standup Explosions",
     "equipment": ["partner"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "compound",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4954,8 +4923,8 @@
   {
     "name": "Uppercut Barrage",
     "equipment": ["angle bag"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "8x / 60s rest",
     "intensity": "max",
@@ -4966,8 +4935,8 @@
   {
     "name": "Spinning Back Kick Accelerations",
     "equipment": ["thai pads"],
-    "phases": ["gpp"],
-    "system": "atp-pcr",
+    "phases": ["GPP"],
+    "system": "ATP-PCr",
     "modality": "strike",
     "duration": "6x / 60s rest",
     "intensity": "max",
@@ -4978,7 +4947,7 @@
   {
     "name": "Long-Distance Shadowboxing",
     "equipment": ["mirror"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "steady-state",
     "duration": "3-5min rounds",
@@ -4990,7 +4959,7 @@
   {
     "name": "Clinch Marching Rounds",
     "equipment": ["partner"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "4min rounds",
@@ -5002,7 +4971,7 @@
   {
     "name": "Grappler's Flow Roll",
     "equipment": ["partner", "mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min rounds",
@@ -5014,7 +4983,7 @@
   {
     "name": "Teep Maintenance Drill",
     "equipment": ["thai pads"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "2min on / 30s off",
@@ -5026,7 +4995,7 @@
   {
     "name": "Cage Cutting Footwork",
     "equipment": ["cage"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5038,7 +5007,7 @@
   {
     "name": "Pummeling Endurance Rounds",
     "equipment": ["partner"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "4min rounds",
@@ -5050,7 +5019,7 @@
   {
     "name": "Kick Defense March",
     "equipment": ["open space"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min rounds",
@@ -5062,7 +5031,7 @@
   {
     "name": "Brawler's Forward Shadow",
     "equipment": ["mirror"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5074,7 +5043,7 @@
   {
     "name": "Hybrid Stance Switch Drill",
     "equipment": ["cones"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "1min on / 30s off",
@@ -5086,7 +5055,7 @@
   {
     "name": "Thai Skip Rope",
     "equipment": ["jump rope"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "10min",
@@ -5098,7 +5067,7 @@
   {
     "name": "Octagon Footwork Gauntlet",
     "equipment": ["cage"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min rounds",
@@ -5110,7 +5079,7 @@
   {
     "name": "Counter Striker's Retreat Drill",
     "equipment": ["open space"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5122,7 +5091,7 @@
   {
     "name": "Submission Hunter's Guard Retention",
     "equipment": ["partner", "mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "4min rounds",
@@ -5134,7 +5103,7 @@
   {
     "name": "Kicker's Range Management",
     "equipment": ["mirror"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5146,7 +5115,7 @@
   {
     "name": "Wrestler's Wall-Walk Drill",
     "equipment": ["wall", "mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "1min on / 30s off",
@@ -5158,7 +5127,7 @@
   {
     "name": "Pressure Fighter's Cutoff Circuit",
     "equipment": ["cones"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5170,7 +5139,7 @@
   {
     "name": "Hybrid's Stance Transition Drill",
     "equipment": ["open space"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min",
@@ -5182,7 +5151,7 @@
   {
     "name": "Clinch Fighter's Neck Endurance",
     "equipment": ["partner"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "isometric",
     "duration": "3min rounds",
@@ -5194,7 +5163,7 @@
   {
     "name": "Scrambler's Turtle Recovery",
     "equipment": ["mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "1min on / 30s off",
@@ -5206,7 +5175,7 @@
   {
     "name": "Brawler's Body Shot Guard",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5218,7 +5187,7 @@
   {
     "name": "Distance Striker's Angle Drill",
     "equipment": ["cones"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5230,7 +5199,7 @@
   {
     "name": "MMA Wall-Walk Conditioning",
     "equipment": ["cage"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "45s on / 15s off",
@@ -5242,7 +5211,7 @@
   {
     "name": "Counter Striker's Parry Drill",
     "equipment": ["double-end bag"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5254,7 +5223,7 @@
   {
     "name": "Kicker's Switch Stance March",
     "equipment": ["open space"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min",
@@ -5266,7 +5235,7 @@
   {
     "name": "Grappler's Standup Chain",
     "equipment": ["partner", "mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "1min on / 30s off",
@@ -5278,7 +5247,7 @@
   {
     "name": "Pressure Fighter's Cutoff Shadow",
     "equipment": ["mirror"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5290,7 +5259,7 @@
   {
     "name": "Clinch Fighter's Frame Endurance",
     "equipment": ["partner"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "isometric",
     "duration": "3min rounds",
@@ -5302,7 +5271,7 @@
   {
     "name": "Hybrid's Transition Circuit",
     "equipment": ["open space"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "5min",
@@ -5314,7 +5283,7 @@
   {
     "name": "Scrambler's Hip Escape Marathon",
     "equipment": ["mat"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "interval",
     "duration": "1min on / 30s off",
@@ -5326,7 +5295,7 @@
   {
     "name": "Distance Striker's Teep Maintenance",
     "equipment": ["heavy bag"],
-    "phases": ["gpp"],
+    "phases": ["GPP"],
     "system": "aerobic",
     "modality": "continuous",
     "duration": "3min rounds",
@@ -5339,7 +5308,7 @@
   "name": "Shadow Flow Rounds",
   "equipment": ["Bodyweight"],
   "phases": ["SPP"],
-  "system": "Aerobic",
+  "system": "aerobic",
   "modality": "technical endurance",
   "duration": "3min shadowboxing → 1min rest → x5 rounds",
   "intensity": "60-70% effort",
@@ -5351,7 +5320,7 @@
     "name": "Rope Clinch Frames",
     "equipment": ["Heavy Bag"],
     "phases": ["SPP"],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "fatigue resistance",
     "duration": "30s rope lean → 30s active framing → x8 rounds",
     "intensity": "RPE 5",
@@ -5363,7 +5332,7 @@
     "name": "Referee Break Counters",
     "equipment": ["Partner"],
     "phases": ["SPP"],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "rulebook exploitation",
     "duration": "10s clinch → 2s break → immediate jab → x20 rounds",
     "intensity": "50% speed",
@@ -5375,7 +5344,7 @@
     "name": "Overhook Uppercut Drill",
     "equipment": ["Double-End Bag"],
     "phases": ["SPP"],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "infighting transitions",
     "duration": "20s overhook control → 10s uppercuts → x10 rounds",
     "intensity": "40% power",
@@ -5387,7 +5356,7 @@
     "name": "Corner Mauling Circuit",
     "equipment": ["Punching Bag", "Wall"],
     "phases": ["SPP"],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "positional dominance",
     "duration": "45s bag pinned to wall → 15s frame adjustments → x6 rounds",
     "intensity": "RPE 4",
@@ -5399,7 +5368,7 @@
     "name": "Slip-Clinch Reaction",
     "equipment": ["Partner"],
     "phases": ["SPP"],
-    "system": "Aerobic",
+    "system": "aerobic",
     "modality": "defensive clinching",
     "duration": "Partner jabs → slip → clinch → x50 reps",
     "intensity": "30% speed",
@@ -5410,7 +5379,7 @@
   {
     "name": "Reaction Jab Matrix",
     "equipment": ["Reaction Ball", "Partner"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "visual processing",
     "duration": "3min random ball toss → jab/parry response → x4 rounds",
@@ -5422,7 +5391,7 @@
   {
     "name": "Clinch Auditory Triggers",
     "equipment": ["Bluetooth Speaker"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "auditory reaction",
     "duration": "5min clinch pummeling → change direction on beep → x3 rounds",
@@ -5434,7 +5403,7 @@
   {
     "name": "Wrestling Chess",
     "equipment": ["Chess Clock", "Partner"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "decision fatigue",
     "duration": "3min live wrestling → 30s chess move → x5 rounds",
@@ -5446,7 +5415,7 @@
   {
     "name": "Kick Pattern Recall",
     "equipment": ["Flashcards"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "memory challenge",
     "duration": "3min execute kick combos from flashed cards → x4 rounds",
@@ -5458,7 +5427,7 @@
   {
     "name": "Takedown Dilemma",
     "equipment": ["Colored Cones"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "choice reaction",
     "duration": "3min shot entries → cone color dictates finish (single/double) → x4 rounds",
@@ -5470,7 +5439,7 @@
   {
     "name": "Brawler's Puzzle Defense",
     "equipment": ["Puzzle Mat"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "pattern recognition",
     "duration": "3min mitt work → solve 3 puzzle pieces between rounds → x5 rounds",
@@ -5482,7 +5451,7 @@
   {
     "name": "Distance Striker's Math Dodge",
     "equipment": ["Whiteboard"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "dual-task loading",
     "duration": "3min footwork drills → solve math problem between combos → x4 rounds",
@@ -5494,7 +5463,7 @@
   {
     "name": "Grappler's Blindfold Pummeling",
     "equipment": ["Blindfold"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "tactile sensitivity",
     "duration": "3min pummeling blindfolded → x4 rounds",
@@ -5506,7 +5475,7 @@
   {
     "name": "Pressure Fighter's Shadowboxing Riddle",
     "equipment": ["Earbuds"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "audio distraction",
     "duration": "3min shadowboxing → answer riddle mid-round → x4 rounds",
@@ -5518,7 +5487,7 @@
   {
     "name": "Hybrid's Stance-Switch Reaction",
     "equipment": ["Colored Lights"],
-    "phases": ["SPP", "Taper"],
+    "phases": ["SPP", "TAPER"],
     "system": "Cognitive",
     "modality": "visual cueing",
     "duration": "3min light color dictates stance (red=orthodox/blue=southpaw) → x5 rounds",

--- a/data/style_taper_conditioning.json
+++ b/data/style_taper_conditioning.json
@@ -5,7 +5,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "system": "ATP-PCr",
     "modality": "reactive timing",
@@ -25,7 +25,7 @@
       "Med Ball"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "system": "ATP-PCr",
     "modality": "upper-body explosiveness",
@@ -45,7 +45,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "system": "ATP-PCr",
     "modality": "hip switch power",
@@ -65,7 +65,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "system": "ATP-PCr",
     "modality": "leg recoil",
@@ -85,7 +85,7 @@
       "Plyo Box"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 box step-ups (explosive drive)",
     "intensity": "50% height",
@@ -106,7 +106,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 seated hip pops (from guard)",
     "intensity": "Light explosiveness",
@@ -125,7 +125,7 @@
       "Agility Ladder"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 stance switches (with arm swing)",
     "intensity": "60% speed",
@@ -146,7 +146,7 @@
       "Med Ball"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "5x3 med ball slams (8lb)",
     "intensity": "70% power",
@@ -164,7 +164,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 backward skips (quick toe-off)",
     "intensity": "50% effort",
@@ -184,7 +184,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 level-change jumps",
     "intensity": "40% explosion",
@@ -203,7 +203,7 @@
       "Wall"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 wall push jumps (single leg)",
     "intensity": "50% power",
@@ -221,7 +221,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 skipping knee drives",
     "intensity": "30% power",
@@ -239,7 +239,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 slip-to-vertical jumps",
     "intensity": "50% height",
@@ -258,7 +258,7 @@
       "Tire"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 tire stomps (alternating)",
     "intensity": "60% power",
@@ -276,7 +276,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 stance-switch hops",
     "intensity": "40% effort",
@@ -295,7 +295,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x3 bridge-to-hip lifts",
     "intensity": "Light explosiveness",
@@ -314,7 +314,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 sprawl-to-vertical jumps",
     "intensity": "50% height",
@@ -332,7 +332,7 @@
       "Med Ball"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "5x3 rotational med ball throws",
     "intensity": "60% power",
@@ -350,7 +350,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 lead-leg drive pops",
     "intensity": "40% effort",
@@ -370,7 +370,7 @@
       "Mat"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x3 Granby pop-ups",
     "intensity": "Light explosiveness",
@@ -389,7 +389,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 sprawl-to-forward jumps",
     "intensity": "50% distance",
@@ -407,7 +407,7 @@
       "Partner"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 pummel-to-frame jumps",
     "intensity": "30% power",
@@ -425,7 +425,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 pull-counter to jump",
     "intensity": "50% height",
@@ -443,7 +443,7 @@
       "Agility Ladder"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 lateral cutoff hops",
     "intensity": "50% effort",
@@ -461,7 +461,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 switch-kick footwork pops",
     "intensity": "40% effort",
@@ -480,7 +480,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 sit-out to stand jumps",
     "intensity": "Light explosiveness",
@@ -499,7 +499,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 shot-entry hops",
     "intensity": "50% distance",
@@ -518,7 +518,7 @@
       "Med Ball"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "5x3 med ball body drops",
     "intensity": "60% power",
@@ -537,7 +537,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 forward skips (quick plant)",
     "intensity": "50% effort",
@@ -555,7 +555,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 hip heist pops",
     "intensity": "Light explosiveness",
@@ -574,7 +574,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x3 spin-to-jump transitions",
     "intensity": "40% power",
@@ -592,7 +592,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 long guard advance hops",
     "intensity": "30% effort",
@@ -610,7 +610,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 check hook to jump",
     "intensity": "50% height",
@@ -628,7 +628,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 pivot hops",
     "intensity": "40% effort",
@@ -647,7 +647,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 arm drag to jump",
     "intensity": "Light explosiveness",
@@ -666,7 +666,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 sprawl-to-spin jumps",
     "intensity": "40% rotation",
@@ -683,7 +683,7 @@
       "Battle Ropes"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 rope waves to jump",
     "intensity": "50% power",
@@ -701,7 +701,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 lateral slide jumps",
     "intensity": "50% effort",
@@ -719,7 +719,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x4 knee cut drives",
     "intensity": "Light explosiveness",
@@ -738,7 +738,7 @@
       "Wall"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 wall push-off jumps",
     "intensity": "50% height",
@@ -756,7 +756,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 skip knee drives",
     "intensity": "30% power",
@@ -774,7 +774,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 shoulder roll to jump",
     "intensity": "50% height",
@@ -792,7 +792,7 @@
       "Tire"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 stomp-to-stance switch",
     "intensity": "50% speed",
@@ -810,7 +810,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "4x3 stance-switch teep pops",
     "intensity": "40% effort",
@@ -828,7 +828,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x3 bridge to stand jumps",
     "intensity": "Light explosiveness",
@@ -847,7 +847,7 @@
       "Bodyweight"
     ],
     "phases": [
-      "Taper"
+      "TAPER"
     ],
     "duration": "3x5 shot to jump transitions",
     "intensity": "50% height",
@@ -861,7 +861,7 @@
   {
     "name": "Reaction Jab Matrix",
     "equipment": ["Reaction Ball", "Partner"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "visual processing",
     "duration": "3min random ball toss → jab/parry response → x4 rounds",
@@ -873,7 +873,7 @@
   {
     "name": "Clinch Auditory Triggers",
     "equipment": ["Bluetooth Speaker"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "auditory reaction",
     "duration": "5min clinch pummeling → change direction on beep → x3 rounds",
@@ -885,7 +885,7 @@
   {
     "name": "Wrestling Chess",
     "equipment": ["Chess Clock", "Partner"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "decision fatigue",
     "duration": "3min live wrestling → 30s chess move → x5 rounds",
@@ -897,7 +897,7 @@
   {
     "name": "Kick Pattern Recall",
     "equipment": ["Flashcards"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "memory challenge",
     "duration": "3min execute kick combos from flashed cards → x4 rounds",
@@ -909,7 +909,7 @@
   {
     "name": "Takedown Dilemma",
     "equipment": ["Colored Cones"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "choice reaction",
     "duration": "3min shot entries → cone color dictates finish (single/double) → x4 rounds",
@@ -921,7 +921,7 @@
   {
     "name": "Brawler's Puzzle Defense",
     "equipment": ["Puzzle Mat"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "pattern recognition",
     "duration": "3min mitt work → solve 3 puzzle pieces between rounds → x5 rounds",
@@ -933,7 +933,7 @@
   {
     "name": "Distance Striker's Math Dodge",
     "equipment": ["Whiteboard"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "dual-task loading",
     "duration": "3min footwork drills → solve math problem between combos → x4 rounds",
@@ -945,7 +945,7 @@
   {
     "name": "Grappler's Blindfold Pummeling",
     "equipment": ["Blindfold"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "tactile sensitivity",
     "duration": "3min pummeling blindfolded → x4 rounds",
@@ -957,7 +957,7 @@
   {
     "name": "Pressure Fighter's Shadowboxing Riddle",
     "equipment": ["Earbuds"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "audio distraction",
     "duration": "3min shadowboxing → answer riddle mid-round → x4 rounds",
@@ -969,7 +969,7 @@
   {
     "name": "Hybrid's Stance-Switch Reaction",
     "equipment": ["Colored Lights"],
-    "phases": ["Taper"],
+    "phases": ["TAPER"],
     "system": "Cognitive",
     "modality": "visual cueing",
     "duration": "3min light color dictates stance (red=orthodox/blue=southpaw) → x5 rounds",

--- a/data/universal_gpp_conditioning.json
+++ b/data/universal_gpp_conditioning.json
@@ -2,7 +2,7 @@
   {
     "phase": "GPP",
     "name": "Steady-State Cardio (Run / Bike / Row)",
-    "system": "Aerobic",
+    "system": "aerobic",
     "duration": "30–60 minutes",
     "intensity": "60–70% max HR (Zone 2)",
     "volume": "2–3x/week",
@@ -13,7 +13,7 @@
   {
     "phase": "GPP",
     "name": "Jump Rope Endurance (Footwork Conditioning)",
-    "system": "Aerobic + Coordination",
+    "system": "aerobic + coordination",
     "duration": "3–5 rounds × 3–5 minutes",
     "intensity": "Moderate steady pace",
     "volume": "2–4x/week",
@@ -35,7 +35,7 @@
   {
     "phase": "GPP",
     "name": "Battle Rope Circuits",
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "duration": "4–6 rounds × 30s work",
     "intensity": "High effort",
     "volume": "1–2x/week",
@@ -46,7 +46,7 @@
   {
     "phase": "GPP",
     "name": "Bodyweight MetCon Circuit",
-    "system": "Glycolytic",
+    "system": "glycolytic",
     "duration": "3–4 rounds of 3–5 exercises × 30s each",
     "intensity": "High tempo",
     "volume": "1–2x/week",

--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -12,8 +12,12 @@ from pathlib import Path
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 
-# Load exercise bank
-exercise_bank = json.loads((DATA_DIR / "exercise_bank.json").read_text())
+# Load exercise bank, handle potential parse issues during minimal runs
+try:
+    exercise_bank = json.loads((DATA_DIR / "exercise_bank.json").read_text())
+except json.JSONDecodeError:
+    exercise_bank = []
+    print("⚠️  exercise_bank.json is invalid; continuing with empty list")
 
 # Modules
 from .training_context import allocate_sessions, normalize_equipment_list

--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -1,4 +1,26 @@
-from rapidfuzz import fuzz
+try:
+    from rapidfuzz import fuzz
+except ImportError:  # Fallback for minimal environments
+    from difflib import SequenceMatcher
+
+    def fuzz(s1: str, s2: str) -> float:
+        return SequenceMatcher(None, s1, s2).ratio() * 100
+
+    class FuzzWrapper:
+        @staticmethod
+        def partial_ratio(a: str, b: str) -> float:
+            if not a or not b:
+                return 0.0
+            shorter, longer = (a, b) if len(a) <= len(b) else (b, a)
+            max_score = 0.0
+            for i in range(len(longer) - len(shorter) + 1):
+                segment = longer[i:i+len(shorter)]
+                score = fuzz(shorter, segment)
+                if score > max_score:
+                    max_score = score
+            return max_score
+
+    fuzz = FuzzWrapper()
 
 mindset_bank = {
     "GPP": {

--- a/fightcamp/strength.py
+++ b/fightcamp/strength.py
@@ -140,7 +140,11 @@ def is_banned_exercise(name: str, tags: list[str], fight_format: str, details: s
 
     return False
 
-exercise_bank = json.loads((DATA_DIR / "exercise_bank.json").read_text())
+try:
+    exercise_bank = json.loads((DATA_DIR / "exercise_bank.json").read_text())
+except json.JSONDecodeError:
+    exercise_bank = []
+    print("⚠️  exercise_bank.json is invalid; continuing with empty list")
 
 def generate_strength_block(*, flags: dict, weaknesses=None, mindset_cue=None):
     phase = flags.get("phase", "GPP").upper()


### PR DESCRIPTION
## Summary
- remove duplicate drills in style conditioning bank
- standardize phase and system case values
- normalize GPP conditioning data
- handle missing rapidfuzz dependency
- continue gracefully when exercise bank JSON is invalid

## Testing
- `python -m fightcamp.main --help`

------
https://chatgpt.com/codex/tasks/task_e_684ec1bddfb8832ead0c1c4f728d971a