### PR TITLE
Improve mental block classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `hybrid` style tag refers to stance-switching ability rather than mixing mul
 
 **Mindset module** (`mindset_module.py`)
 
-Keyword counts determine the top mental blocks. The two highest scoring blocks feed into the phase mindset cues.
+Keyword counts determine the top mental blocks using fuzzy matching. If no clear keyword hits are found, the module falls back to a semantic similarity check via spaCy. The two highest scoring blocks feed into the phase mindset cues.
 
 **Training context** (`training_context.py`)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ google-auth-oauthlib
 rapidfuzz
 gspread
 oauth2client
+spacy
+en_core_web_lg @ https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.6.0/en_core_web_lg-3.6.0-py3-none-any.whl


### PR DESCRIPTION
## Summary
- load large spaCy model at start of mindset module
- add semantic fallback using spaCy similarity
- update `classify_mental_block` to use hybrid approach
- document semantic fallback
- add spaCy packages to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m fightcamp.main` *(fails: ModuleNotFoundError for rapidfuzz)*

------
https://chatgpt.com/codex/tasks/task_e_684ecb212500832eb03b482ffd30b0d9