### PR TITLE
Improve offline compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ notes/     → Reference JSON and tag documentation
 
 Run the application with `python -m fightcamp.main` from the project root.
 
+### Dependencies
+
+The code relies on `numpy`, `spacy` and the `en_core_web_lg` language model. If the
+spaCy model isn't available, the mindset module gracefully skips semantic similarity
+matching and relies solely on keyword heuristics.
+
 Recent updates removed the OpenAI dependency and now build plans entirely from the module outputs. Short-camp handling and style-specific rules still adjust the phase weeks correctly via the helper `_apply_style_rules()`.
 
 The **Fighting Style (Technical)** field accepts a comma-separated list when an athlete has more than one technical base (e.g. `boxing, wrestling`). The style that appears first in this list sets the fight format while conditioning drills consider every style provided.

--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -1,8 +1,12 @@
 from rapidfuzz import fuzz
-import spacy
 
-# load large English model once
-nlp = spacy.load("en_core_web_lg")
+try:
+    import spacy
+    nlp = spacy.load("en_core_web_lg")
+except Exception as e:  # spaCy or model may be missing in offline environments
+    spacy = None
+    nlp = None
+    print("\u26a0\ufe0f  spaCy large model not available; semantic similarity disabled.", e)
 
 mindset_bank = {
     "GPP": {
@@ -122,6 +126,8 @@ mental_blocks = {
 def semantic_match_block(text: str, threshold: float = 0.78) -> str:
     """Use spaCy embeddings to match unknown input to nearest mental block category."""
     if not text.strip():
+        return "generic"
+    if not nlp:
         return "generic"
 
     doc_input = nlp(text.strip().lower())


### PR DESCRIPTION
## Summary
- handle missing spaCy model in `mindset_module`
- document optional dependency in README

## Testing
- `python -m py_compile fightcamp/mindset_module.py`
- `python -m py_compile fightcamp/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684eceef8460832ea642dc7cc569d28b