### PR TITLE
Fix attention classification keywords

### DIFF
--- a/fightcamp/mindset_module.py
+++ b/fightcamp/mindset_module.py
@@ -73,13 +73,14 @@ mental_blocks = {
         "contract", "rank", "title", "break", "perform", "count", "blank"
     ],
     "attention": [
-        "focus", "distract", "adhd", "concentrat", "lapse", "zone", 
-        "wander", "scatter", "overstim", "crowd", "noise", "trash", 
-        "personal", "emotional", "overload", "indecisive", "slow", 
-        "forget", "space", "deficit", "sensory", "thought", "lock", 
-        "sidetrack", "clarity", "fog", "brain", "decide", "fatigue", 
-        "aware", "opponent", "track", "chaotic", "sloppy", "mistake", 
-        "rush", "impulsive", "gameplan", "absent", "daydream", "unaware"
+        "focus", "distract", "adhd", "concentrat", "lapse", "zone",
+        "wander", "scatter", "overstim", "crowd", "noise", "trash",
+        "personal", "emotional", "overload", "indecisive", "slow",
+        "forget", "space", "deficit", "sensory", "thought", "lock",
+        "sidetrack", "clarity", "fog", "brain", "decide", "fatigue",
+        "aware", "opponent", "track", "chaotic", "sloppy", "mistake",
+        "rush", "impulsive", "gameplan", "absent", "daydream", "unaware",
+        "zoning", "zoned", "zoned out", "spacey", "dizzy", "spinning"
     ],
     "motivation": [
         "lazy", "bother", "energy", "motivat", "train", "inspire", 


### PR DESCRIPTION
## Summary
- add additional synonyms for the "attention" mental block

## Testing
- `python -m fightcamp.main test_data.json` *(fails: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_684edb992190832eb32a2856ac6ce4f2