### PR TITLE
Normalize shoulder tag variants

### DIFF
--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -88,6 +88,7 @@ weakness_tag_map = {
     "balance": ["balance", "stability", "unilateral"],
     "explosiveness": ["explosive", "rate_of_force", "plyometric"],
     "shoulders": ["shoulders", "upper_body"],
+    "shoulder": ["shoulders", "upper_body"],
     "hip mobility": ["hip_dominant", "mobility"],
     "grip strength": ["grip", "pull"],
     "posterior chain": ["posterior_chain", "hip_dominant"],

--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -43,6 +43,7 @@ GOAL_NORMALIZER = {
     "Rotation": "rotational",
     "Balance": "balance",
     "Shoulders": "shoulders",
+    "Shoulder": "shoulders",
     "Hip Mobility": "hip",
     "Grip Strength": "grip",
     "Posterior Chain": "posterior_chain",
@@ -61,6 +62,8 @@ GOAL_NORMALIZER = {
 WEAKNESS_NORMALIZER = {
     "coordination / proprioception": ["coordination"],
     "coordination/proprioception": ["coordination"],
+    "shoulder": ["shoulders"],
+    "shoulders": ["shoulders"],
 }
 
 try:


### PR DESCRIPTION
## Summary
- map `Shoulder` to `shoulders` in goal normalization
- normalize singular shoulder entry when parsing weaknesses
- handle `shoulder` in conditioning weakness tag map

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684eeffc8d18832eb2aa2ec66c9622c0