### PR TITLE
Fix location parsing edge case

### DIFF
--- a/fightcamp/recovery.py
+++ b/fightcamp/recovery.py
@@ -29,8 +29,8 @@ def _fetch_injury_drills(injuries: list, phase: str) -> list:
         itype, loc = parse_injury_phrase(desc)
         if itype:
             injury_types.add(itype)
-        if loc:
-            locations.add(loc)
+            if loc:
+                locations.add(loc)
 
     drills = []
 

--- a/fightcamp/rehab_protocols.py
+++ b/fightcamp/rehab_protocols.py
@@ -167,10 +167,10 @@ def generate_rehab_protocols(
     parsed_types = []
     for phrase in injury_phrases:
         itype, loc = parse_injury_phrase(phrase)
-        if itype:
-            parsed_types.append(itype)
-        if itype or loc:
-            parsed_entries.append((itype, loc))
+        if not itype:
+            continue
+        parsed_types.append(itype)
+        parsed_entries.append((itype, loc))
 
     # Prioritize specific injuries over unspecified duplicates
     parsed_entries.sort(key=lambda x: (x[0] is None or x[0] == "unspecified"))


### PR DESCRIPTION
## Summary
- avoid saving locations when the injury type isn't recognized
- skip phrases lacking a valid injury type when generating rehab protocols

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f25922874832e968d688aae9ec914