### PR TITLE
Fix boxing style mapping and training day field

### DIFF
--- a/fightcamp/conditioning.py
+++ b/fightcamp/conditioning.py
@@ -256,8 +256,11 @@ def generate_conditioning_block(flags):
     style_map = {
         "mma": "mma",
         "boxer": "boxing",
+        "boxing": "boxing",
         "kickboxer": "kickboxing",
+        "kickboxing": "kickboxing",
         "muay thai": "muay_thai",
+        "muaythai": "muay_thai",
         "bjj": "mma",
         "wrestler": "mma",
         "wrestling": "wrestler",

--- a/fightcamp/main.py
+++ b/fightcamp/main.py
@@ -151,7 +151,7 @@ async def generate_plan(data: dict):
     frequency_raw = get_value("Weekly Training Frequency", fields)
     fatigue = get_value("Fatigue Level", fields)
     equipment_access = get_value("Equipment Access", fields)
-    available_days = get_value("Time Availability for Training", fields)
+    available_days = get_value("Training Availability", fields)
 
     # Normalize schedule info
     training_days = [d.strip() for d in available_days.split(',') if d.strip()]


### PR DESCRIPTION
## Summary
- include common synonyms for boxing, kickboxing and muay thai in `conditioning.py`
- read `Training Availability` field instead of incorrect label in `main.py`

## Testing
- `python -m fightcamp.main test_data.json` *(fails: ModuleNotFoundError: No module named 'rapidfuzz')*

------
https://chatgpt.com/codex/tasks/task_e_6852852bbbe8832e899306e69316a9fe