### PR TITLE
Refactor mindcode tag mapping and add tests

### DIFF
--- a/mental/map_mindcode_tags.py
+++ b/mental/map_mindcode_tags.py
@@ -1,49 +1,95 @@
-"""Mapping helpers for mindcode form fields."""
+"""Mapping helpers for mindcode form fields.
 
-# Valid input phrases per field. These mirror the Google form options and allow
-# simple mapping without long ``if/elif`` chains.
-BREATH_OPTIONS = ["hold", "shallow", "normal"]
-HR_OPTIONS = ["spike", "drop", "normal"]
-RESET_OPTIONS = ["instant", "10", "1", "long"]
-MOTIVATOR_OPTIONS = ["avoid", "compete", "praise", "wins"]
-TRIGGER_OPTIONS = ["coach", "crowd", "team"]
+Each mapping dictionary key corresponds to an exact option from the Google form
+(lowercased).  Using lookups keeps the logic explicit and avoids broad
+substring checks.
+"""
 
+from typing import Any, Dict, List, Union
+
+# Multi-select option -> tag lookups
+UNDER_PRESSURE_MAP = {
+    "i hesitate before acting": "hesitate",
+    "i go blank or freeze": "freeze",
+    "i second-guess good decisions": "second_guess",
+    "i get angry and emotional": "emotional",
+    "i overthink instead of trusting instinct": "overthink",
+    "i play safe or avoid mistakes": "avoidant",
+    "i stop listening or can’t hear instructions": "audio_cutoff",
+    "i get scared to demand the ball or take shots": "demand_avoidance",
+    "i feel calm and thrive under pressure": "thrives",
+}
+
+POST_MISTAKE_MAP = {
+    "i replay it over and over in my head": "mental_loop",
+    "i get quieter or withdrawn": "shutdown",
+    "i try to make up for it too quickly": "compensate",
+    "i stop wanting the ball or engaging": "disengage",
+    "i get tense or angry with myself": "self_anger",
+    "i shake it off quickly and move on": "quick_reset",
+    "i start thinking of what others will say": "external_judgement",
+}
+
+FOCUS_BREAKERS_MAP = {
+    "the crowd / noise": "focus_crowd",
+    "coach instructions": "focus_coach",
+    "fear of making the wrong choice": "focus_decision_fear",
+    "getting tired / out of breath": "focus_fatigue",
+    "my own inner critic": "focus_self_critic",
+    "teammates or opponents": "focus_social",
+    "i rarely lose focus": "focus_locked",
+}
+
+CONFIDENCE_PROFILE_MAP = {
+    "i train better than i perform": "gym_performer",
+    "i lose confidence easily after mistakes": "fragile_confidence",
+    "i struggle to perform freely in front of others": "stage_fear",
+    "i don’t trust myself in high-pressure moments": "pressure_distrust",
+    "i perform better when i’m emotional": "emotional_performer",
+    "i need to feel in control to perform": "control_needed",
+    "i am confident in myself, regardless of outcome": "stable_confidence",
+}
+
+# Single-select option -> tag lookups
 BREATH_MAP = {
-    "hold": "breath_hold",
-    "shallow": "breath_fast",
-    "normal": "breath_normal",
+    "hold my breath": "breath_hold",
+    "breathe shallow": "breath_fast",
+    "breathe normally": "breath_normal",
+    "no idea": "breath_unknown",
 }
 
 HR_RESPONSE_MAP = {
-    "spike": "hr_up",
-    "drop": "hr_down",
-    "normal": "hr_stable",
+    "spikes": "hr_up",
+    "drops": "hr_down",
+    "feels normal": "hr_stable",
+    "not sure": "hr_unknown",
 }
 
 RESET_SPEED_MAP = {
-    "instant": "fast_reset",
-    "10": "medium_reset",
-    "1": "slow_reset",
-    "long": "very_slow_reset",
+    "instantly": "fast_reset",
+    "10–30 seconds": "medium_reset",
+    "1–2 minutes": "slow_reset",
+    "longer": "very_slow_reset",
 }
 
 MOTIVATOR_MAP = {
-    "avoid": "avoid_failure",
-    "compete": "competitive",
-    "praise": "external_validation",
-    "wins": "reward_seeker",
+    "avoid failure": "avoid_failure",
+    "competing with others": "competitive",
+    "praise from others": "external_validation",
+    "small visible wins": "reward_seeker",
 }
 
 EMOTIONAL_TRIGGER_MAP = {
-    "coach": "authority_threat",
-    "crowd": "audience_threat",
-    "team": "peer_threat",
+    "coach criticism": "authority_threat",
+    "crowd pressure": "audience_threat",
+    "teammate judgement": "peer_threat",
+    "i don’t know / i zoned out": "general_threat",
 }
 
 
-def map_mindcode_tags(form_data: dict) -> dict:
-    """Maps mental form inputs into controlled tag outputs."""
-    tags = {
+def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[str]]]:
+    """Map raw form input to controlled mental performance tags."""
+    tags: Dict[str, Union[str, List[str]]] = {
         "under_pressure": [],
         "post_mistake": [],
         "focus_breakers": [],
@@ -58,81 +104,17 @@ def map_mindcode_tags(form_data: dict) -> dict:
         "mental_history": "clear_history",
     }
 
-    # === UNDER PRESSURE ===
-    for item in form_data.get("under_pressure", []):
-        item = item.lower()
-        if "freeze" in item or "blank" in item:
-            tags["under_pressure"].append("freeze")
-        elif "overthink" in item:
-            tags["under_pressure"].append("overthink")
-        elif "hesitate" in item:
-            tags["under_pressure"].append("hesitate")
-        elif "second-guess" in item:
-            tags["under_pressure"].append("second_guess")
-        elif "emotional" in item:
-            tags["under_pressure"].append("emotional")
-        elif "safe" in item or "avoid" in item:
-            tags["under_pressure"].append("avoidant")
-        elif "stop listening" in item:
-            tags["under_pressure"].append("audio_cutoff")
-        elif "scared" in item:
-            tags["under_pressure"].append("demand_avoidance")
-        elif "thrive" in item:
-            tags["under_pressure"].append("thrives")
-
-    # === POST MISTAKE ===
-    for item in form_data.get("post_mistake", []):
-        item = item.lower()
-        if "replay" in item:
-            tags["post_mistake"].append("mental_loop")
-        elif "quieter" in item or "withdrawn" in item:
-            tags["post_mistake"].append("shutdown")
-        elif "make up" in item:
-            tags["post_mistake"].append("compensate")
-        elif "stop wanting" in item:
-            tags["post_mistake"].append("disengage")
-        elif "angry" in item:
-            tags["post_mistake"].append("self_anger")
-        elif "shake it off" in item:
-            tags["post_mistake"].append("quick_reset")
-        elif "others" in item:
-            tags["post_mistake"].append("external_judgement")
-
-    # === FOCUS BREAKERS ===
-    for item in form_data.get("focus_breakers", []):
-        item = item.lower()
-        if "crowd" in item or "noise" in item:
-            tags["focus_breakers"].append("focus_crowd")
-        elif "coach" in item:
-            tags["focus_breakers"].append("focus_coach")
-        elif "fear" in item or "wrong" in item:
-            tags["focus_breakers"].append("focus_decision_fear")
-        elif "tired" in item or "breath" in item:
-            tags["focus_breakers"].append("focus_fatigue")
-        elif "critic" in item:
-            tags["focus_breakers"].append("focus_self_critic")
-        elif "teammates" in item or "opponents" in item:
-            tags["focus_breakers"].append("focus_social")
-        elif "rarely" in item:
-            tags["focus_breakers"].append("focus_locked")
-
-    # === CONFIDENCE PROFILE ===
-    for item in form_data.get("confidence_profile", []):
-        item = item.lower()
-        if "train better" in item:
-            tags["confidence_profile"].append("gym_performer")
-        elif "lose confidence" in item:
-            tags["confidence_profile"].append("fragile_confidence")
-        elif "perform freely" in item:
-            tags["confidence_profile"].append("stage_fear")
-        elif "high-pressure" in item:
-            tags["confidence_profile"].append("pressure_distrust")
-        elif "emotional" in item:
-            tags["confidence_profile"].append("emotional_performer")
-        elif "control" in item:
-            tags["confidence_profile"].append("control_needed")
-        elif "confident" in item:
-            tags["confidence_profile"].append("stable_confidence")
+    # === MULTI-SELECT FIELDS ===
+    for field, mapping in [
+        ("under_pressure", UNDER_PRESSURE_MAP),
+        ("post_mistake", POST_MISTAKE_MAP),
+        ("focus_breakers", FOCUS_BREAKERS_MAP),
+        ("confidence_profile", CONFIDENCE_PROFILE_MAP),
+    ]:
+        for item in form_data.get(field, []):
+            normalized = item.strip().lower()
+            if normalized in mapping:
+                tags[field].append(mapping[normalized])
 
     # === IDENTITY TRAITS ===
     tags["identity_traits"] = [
@@ -145,29 +127,28 @@ def map_mindcode_tags(form_data: dict) -> dict:
     ]
 
     # === SINGLE SELECTS ===
-    pressure_breath = form_data.get("pressure_breath", "").lower()
-    heart_response = form_data.get("heart_response", "").lower()
-    reset_duration = form_data.get("reset_duration", "").lower()
-    motivator = form_data.get("motivator", "").lower()
-    emotional_trigger = form_data.get("emotional_trigger", "").lower()
+    pressure_breath = form_data.get("pressure_breath", "").strip().lower()
+    heart_response = form_data.get("heart_response", "").strip().lower()
+    reset_duration = form_data.get("reset_duration", "").strip().lower()
+    motivator = form_data.get("motivator", "").strip().lower()
+    emotional_trigger = form_data.get("emotional_trigger", "").strip().lower()
 
-    for key, mapping, value in [
+    lookup_pairs = [
         ("breath_pattern", BREATH_MAP, pressure_breath),
         ("hr_response", HR_RESPONSE_MAP, heart_response),
         ("reset_speed", RESET_SPEED_MAP, reset_duration),
         ("motivation_type", MOTIVATOR_MAP, motivator),
         ("threat_trigger", EMOTIONAL_TRIGGER_MAP, emotional_trigger),
-    ]:
-        for phrase, tag in mapping.items():
-            if phrase in value:
-                tags[key] = tag
-                break
+    ]
+    for key, mapping, value in lookup_pairs:
+        if value in mapping:
+            tags[key] = mapping[value]
 
     # === MENTAL HISTORY ===
     history = form_data.get("past_mental_struggles", "").strip()
     tags["mental_history"] = "has_history" if history else "clear_history"
 
-    # Deduplicate list-based tags
+    # Deduplicate lists while preserving order
     for list_key in [
         "under_pressure",
         "post_mistake",
@@ -176,6 +157,6 @@ def map_mindcode_tags(form_data: dict) -> dict:
         "identity_traits",
         "elite_traits",
     ]:
-        tags[list_key] = list(set(tags[list_key]))
+        tags[list_key] = list(dict.fromkeys(tags[list_key]))
 
     return tags

--- a/tests/test_map_mindcode_tags.py
+++ b/tests/test_map_mindcode_tags.py
@@ -1,0 +1,45 @@
+import unittest
+from mental.map_mindcode_tags import map_mindcode_tags
+
+class MapMindcodeTagsTest(unittest.TestCase):
+    def test_basic_mapping(self):
+        data = {
+            "under_pressure": [
+                "I hesitate before acting",
+                "I feel calm and thrive under pressure",
+            ],
+            "post_mistake": ["I replay it over and over in my head"],
+            "focus_breakers": ["The crowd / noise"],
+            "confidence_profile": ["I train better than I perform"],
+            "identity_traits": ["Confident", "Focused"],
+            "elite_traits": ["Unshakeable focus", "Dominates under pressure"],
+            "pressure_breath": "Hold my breath",
+            "heart_response": "Spikes",
+            "reset_duration": "Instantly",
+            "motivator": "Small visible wins",
+            "emotional_trigger": "Coach criticism",
+            "past_mental_struggles": "",
+        }
+        tags = map_mindcode_tags(data)
+        self.assertEqual(tags["under_pressure"], ["hesitate", "thrives"])
+        self.assertEqual(tags["post_mistake"], ["mental_loop"])
+        self.assertEqual(tags["focus_breakers"], ["focus_crowd"])
+        self.assertEqual(tags["confidence_profile"], ["gym_performer"])
+        self.assertEqual(tags["identity_traits"], ["trait_confident", "trait_focused"])
+        self.assertEqual(tags["elite_traits"], ["elite_unshakeable_focus", "elite_dominates_under_pressure"])
+        self.assertEqual(tags["breath_pattern"], "breath_hold")
+        self.assertEqual(tags["hr_response"], "hr_up")
+        self.assertEqual(tags["reset_speed"], "fast_reset")
+        self.assertEqual(tags["motivation_type"], "reward_seeker")
+        self.assertEqual(tags["threat_trigger"], "authority_threat")
+        self.assertEqual(tags["mental_history"], "clear_history")
+
+    def test_deduplication(self):
+        data = {
+            "under_pressure": ["I hesitate before acting", "I hesitate before acting"],
+        }
+        tags = map_mindcode_tags(data)
+        self.assertEqual(tags["under_pressure"], ["hesitate"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- streamline `map_mindcode_tags` with explicit option maps
- strip and normalize inputs for consistent matching
- dedupe lists while preserving order
- add unit tests for tag mapping logic

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_685c08a08898832e95f1297e9f655686