### PR TITLE
Implement tag normalization

### DIFF
--- a/mental/map_mindcode_tags.py
+++ b/mental/map_mindcode_tags.py
@@ -7,6 +7,8 @@ substring checks.
 
 from typing import Any, Dict, List, Union
 
+from .normalization import normalize_tag_dict
+
 # Multi-select option -> tag lookups
 UNDER_PRESSURE_MAP = {
     "i hesitate before acting": "hesitate",
@@ -158,5 +160,8 @@ def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[st
         "elite_traits",
     ]:
         tags[list_key] = list(dict.fromkeys(tags[list_key]))
+
+    # Normalize synonymous tags across all fields
+    tags = normalize_tag_dict(tags)
 
     return tags

--- a/mental/normalization.py
+++ b/mental/normalization.py
@@ -1,0 +1,19 @@
+TAG_NORMALIZATION_MAP = {
+    "quick_reset": "fast_reset",
+}
+
+
+def normalize_tag(tag: str) -> str:
+    """Return canonical tag for a possibly synonymous input."""
+    return TAG_NORMALIZATION_MAP.get(tag, tag)
+
+
+def normalize_tag_dict(tags):
+    """Normalize all tag values within a mapping."""
+    normalized = {}
+    for key, value in tags.items():
+        if isinstance(value, list):
+            normalized[key] = [normalize_tag(t) for t in value]
+        else:
+            normalized[key] = normalize_tag(value)
+    return normalized

--- a/mental/tags.py
+++ b/mental/tags.py
@@ -1,5 +1,7 @@
 from typing import Dict, List
 
+from .normalization import normalize_tag_dict
+
 def map_tags(form_data: Dict) -> Dict:
     """Map raw form input to controlled mental performance tags."""
     tags = {
@@ -125,5 +127,8 @@ def map_tags(form_data: Dict) -> Dict:
         tags["mental_history"] = "has_history"
     else:
         tags["mental_history"] = "clear_history"
+
+    # Normalize synonymous tags across all fields
+    tags = normalize_tag_dict(tags)
 
     return tags

--- a/tests/test_map_mindcode_tags.py
+++ b/tests/test_map_mindcode_tags.py
@@ -41,5 +41,14 @@ class MapMindcodeTagsTest(unittest.TestCase):
         tags = map_mindcode_tags(data)
         self.assertEqual(tags["under_pressure"], ["hesitate"])
 
+    def test_normalization(self):
+        data = {
+            "post_mistake": ["I shake it off quickly and move on"],
+            "reset_duration": "Instantly",
+        }
+        tags = map_mindcode_tags(data)
+        self.assertEqual(tags["post_mistake"], ["fast_reset"])
+        self.assertEqual(tags["reset_speed"], "fast_reset")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `normalization.py` with helper to unify synonymous tags
- apply normalization step in mapping modules
- test that `quick_reset` from form data normalizes to `fast_reset`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1d0d9d8c832e96b7bc0b0cfdef4b