### PR TITLE
Implement synergy scoring logic

### DIFF
--- a/mental/scoring.py
+++ b/mental/scoring.py
@@ -1,0 +1,40 @@
+SYNERGY_MAP = {
+    ("visualisation", "breathwork"): ["quick_reset", "thrives"],
+    ("game reset", "breathwork"): ["slow_reset", "emotional"],
+    ("focus drill", "journaling"): ["overthink", "stage_fear"],
+}
+
+ELITE_TRAITS = {"ruthless", "dominates", "commanding"}
+
+
+def check_synergy_match(drill: dict, athlete_tags):
+    """Return True if drill has a valid synergy modality pair and athlete has at least one required tag."""
+    modalities = {m.lower() for m in drill.get("modalities", [])}
+    athlete_tags = {t.lower() for t in athlete_tags}
+    for pair, required in SYNERGY_MAP.items():
+        if set(pair).issubset(modalities):
+            if athlete_tags.intersection(required):
+                return True
+            return False
+    return False
+
+
+def score_drill(drill: dict, athlete_tags, phase: str, athlete: dict) -> float:
+    """Score a drill for an athlete based on phase and traits."""
+    score = 1.0
+
+    intensity = drill.get("intensity", "medium").lower()
+    sport = athlete.get("sport", "").lower()
+    in_camp = athlete.get("in_fight_camp", False)
+
+    if sport not in {"mma", "boxing"} or not in_camp:
+        if phase == "TAPER" and intensity == "high":
+            score -= 0.5
+        elif phase == "GPP" and intensity == "high":
+            score -= 0.2
+
+    if any(trait in ELITE_TRAITS for trait in drill.get("raw_traits", [])):
+        if not check_synergy_match(drill, athlete_tags):
+            score -= 0.2
+
+    return score

--- a/tests/test_map_mindcode_tags.py
+++ b/tests/test_map_mindcode_tags.py
@@ -1,3 +1,5 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 from mental.map_mindcode_tags import map_mindcode_tags
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,33 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from mental.scoring import check_synergy_match, score_drill
+
+class ScoringTests(unittest.TestCase):
+    def test_check_synergy_match(self):
+        drill = {"modalities": ["visualisation", "breathwork"]}
+        self.assertTrue(check_synergy_match(drill, ["quick_reset"]))
+        self.assertFalse(check_synergy_match(drill, ["overthink"]))
+        drill2 = {"modalities": ["visualisation"]}
+        self.assertFalse(check_synergy_match(drill2, ["quick_reset"]))
+
+    def test_phase_intensity_penalty(self):
+        drill = {"intensity": "high", "raw_traits": [], "modalities": []}
+        athlete = {"sport": "football", "in_fight_camp": False}
+        self.assertAlmostEqual(score_drill(drill, [], "GPP", athlete), 0.8)
+        self.assertAlmostEqual(score_drill(drill, [], "TAPER", athlete), 0.5)
+
+    def test_intensity_penalty_skipped_for_fighters(self):
+        drill = {"intensity": "high", "raw_traits": [], "modalities": []}
+        athlete = {"sport": "mma", "in_fight_camp": True}
+        self.assertAlmostEqual(score_drill(drill, [], "GPP", athlete), 1.0)
+
+    def test_elite_trait_synergy_penalty(self):
+        drill = {"intensity": "medium", "raw_traits": ["ruthless"], "modalities": ["focus drill"]}
+        athlete = {"sport": "football", "in_fight_camp": False}
+        self.assertAlmostEqual(score_drill(drill, [], "SPP", athlete), 0.8)
+        drill2 = {"intensity": "medium", "raw_traits": ["commanding"], "modalities": ["visualisation", "breathwork"]}
+        self.assertAlmostEqual(score_drill(drill2, ["thrives"], "SPP", athlete), 1.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new `mental.scoring` module with drill scoring rules
- enforce import path in tests
- add unit tests for synergy and penalty logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6baa8c90832ea470564d7e31fef9