### PR TITLE
Implement trait tiering and synergy scoring

### DIFF
--- a/mental/scoring.py
+++ b/mental/scoring.py
@@ -1,25 +1,45 @@
-SYNERGY_MAP = {
-    ("visualisation", "breathwork"): ["quick_reset", "thrives"],
-    ("game reset", "breathwork"): ["slow_reset", "emotional"],
-    ("focus drill", "journaling"): ["overthink", "stage_fear"],
+TRAIT_SCORES = {
+    # Base Traits (+0.3)
+    "focused": 0.3,
+    "aggressive": 0.3,
+    "resilient": 0.3,
+
+    # Elite Tier 2 (+0.5)
+    "commanding": 0.5,
+    "locked-in": 0.5,
+
+    # Elite Tier 1 (+0.7)
+    "dominates": 0.7,
+    "ruthless": 0.7,
+    "thrives": 0.7,
 }
 
-ELITE_TRAITS = {"ruthless", "dominates", "commanding"}
+SYNERGY_LIST = {
+    ("visualisation", "breathwork"): {"required_tags": ["quick_reset", "thrives"]},
+    ("game reset", "breathwork"): {"required_tags": ["slow_reset", "emotional"]},
+    ("focus drill", "journaling"): {"required_tags": ["overthink", "stage_fear"]},
+    ("anchor cue", "self-talk"): {"required_tags": ["identity_gap", "control_need"]},
+}
+
+ELITE_TRAITS = {"dominates", "ruthless", "thrives", "commanding", "locked-in"}
+
+
+def get_trait_score(trait: str) -> float:
+    return TRAIT_SCORES.get(trait.lower(), 0.0)
 
 
 def check_synergy_match(drill: dict, athlete_tags):
     """Return True if drill has a valid synergy modality pair and athlete has at least one required tag."""
     modalities = {m.lower() for m in drill.get("modalities", [])}
     athlete_tags = {t.lower() for t in athlete_tags}
-    for pair, required in SYNERGY_MAP.items():
+    for pair, data in SYNERGY_LIST.items():
         if set(pair).issubset(modalities):
-            if athlete_tags.intersection(required):
+            if set(data["required_tags"]).intersection(athlete_tags):
                 return True
-            return False
     return False
 
 
-def score_drill(drill: dict, athlete_tags, phase: str, athlete: dict) -> float:
+def score_drill(drill: dict, phase: str, athlete: dict) -> float:
     """Score a drill for an athlete based on phase and traits."""
     score = 1.0
 
@@ -33,8 +53,28 @@ def score_drill(drill: dict, athlete_tags, phase: str, athlete: dict) -> float:
         elif phase == "GPP" and intensity == "high":
             score -= 0.2
 
-    if any(trait in ELITE_TRAITS for trait in drill.get("raw_traits", [])):
-        if not check_synergy_match(drill, athlete_tags):
-            score -= 0.2
+    # --- Trait scoring
+    traits = drill.get("raw_traits", [])
+    trait_score = sum(get_trait_score(t) for t in traits)
+    trait_score = min(trait_score, 1.2)
+    score += trait_score
+
+    athlete_tags = athlete.get("tags", [])
+    synergy_ok = check_synergy_match(drill, athlete_tags)
+
+    # --- Synergy bonus
+    if synergy_ok:
+        score += 0.2
+
+    # --- Elite trait synergy penalties
+    drill_traits = set(traits)
+    has_elite_trait = bool(drill_traits & ELITE_TRAITS)
+
+    if has_elite_trait and not synergy_ok:
+        score -= 0.2
+
+    elite_trait_count = len(drill_traits & ELITE_TRAITS)
+    if elite_trait_count >= 2 and not synergy_ok:
+        score -= 0.2
 
     return score

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -14,20 +14,26 @@ class ScoringTests(unittest.TestCase):
     def test_phase_intensity_penalty(self):
         drill = {"intensity": "high", "raw_traits": [], "modalities": []}
         athlete = {"sport": "football", "in_fight_camp": False}
-        self.assertAlmostEqual(score_drill(drill, [], "GPP", athlete), 0.8)
-        self.assertAlmostEqual(score_drill(drill, [], "TAPER", athlete), 0.5)
+        self.assertAlmostEqual(score_drill(drill, "GPP", athlete), 0.8)
+        self.assertAlmostEqual(score_drill(drill, "TAPER", athlete), 0.5)
 
     def test_intensity_penalty_skipped_for_fighters(self):
         drill = {"intensity": "high", "raw_traits": [], "modalities": []}
         athlete = {"sport": "mma", "in_fight_camp": True}
-        self.assertAlmostEqual(score_drill(drill, [], "GPP", athlete), 1.0)
+        self.assertAlmostEqual(score_drill(drill, "GPP", athlete), 1.0)
 
     def test_elite_trait_synergy_penalty(self):
         drill = {"intensity": "medium", "raw_traits": ["ruthless"], "modalities": ["focus drill"]}
-        athlete = {"sport": "football", "in_fight_camp": False}
-        self.assertAlmostEqual(score_drill(drill, [], "SPP", athlete), 0.8)
+        athlete = {"sport": "football", "in_fight_camp": False, "tags": []}
+        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.5)
         drill2 = {"intensity": "medium", "raw_traits": ["commanding"], "modalities": ["visualisation", "breathwork"]}
-        self.assertAlmostEqual(score_drill(drill2, ["thrives"], "SPP", athlete), 1.0)
+        athlete_synergy = {"sport": "football", "in_fight_camp": False, "tags": ["thrives"]}
+        self.assertAlmostEqual(score_drill(drill2, "SPP", athlete_synergy), 1.7)
+
+    def test_multiple_elite_trait_penalty(self):
+        drill = {"intensity": "medium", "raw_traits": ["ruthless", "commanding"], "modalities": ["focus drill"]}
+        athlete = {"sport": "football", "in_fight_camp": False, "tags": []}
+        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.8)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- introduce trait tiering scores and helper
- add modality synergy list and matching rules
- update scoring logic for trait bonuses and synergy penalties
- extend scoring tests to cover new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d82f07f74832e8505da316c9300aa