### PR TITLE
Refactor drill scoring

### DIFF
--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -49,8 +49,8 @@ class ScoringTests(unittest.TestCase):
             "in_fight_camp": False,
             "tags": ["fast_reset", "breath_hold", "other"],
         }
-        # 1.0 base +0.6 theme +0.05 combat bonus +0.3 sport match +0.5 phase match = 2.35
-        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 2.35)
+        # 1.0 base +0.5 phase match +0.3 sport match -0.1 overload = 1.7
+        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.7)
 
     def test_weakness_and_reinforcement_bonus(self):
         drill = {
@@ -67,8 +67,8 @@ class ScoringTests(unittest.TestCase):
             "weakness_tags": ["overthink"],
             "preferred_modality": ["visualisation"],
         }
-        # 1.0 base +0.4 theme +0.5 phase +0.15 weakness +0.1 reinforcement
-        self.assertAlmostEqual(score_drill(drill, "GPP", athlete), 2.15)
+        # 1.0 base +0.5 phase +0.15 weakness +0.1 reinforcement = 1.75
+        self.assertAlmostEqual(score_drill(drill, "GPP", athlete), 1.75)
 
     def test_overload_penalty(self):
         drill = {
@@ -84,8 +84,8 @@ class ScoringTests(unittest.TestCase):
             "in_fight_camp": False,
             "tags": ["breath_hold"],
         }
-        # Base 1.0 +0.4 theme -0.5 taper penalty -0.2 overload = 0.7
-        self.assertAlmostEqual(score_drill(drill, "TAPER", athlete), 0.7)
+        # Base 1.0 -0.5 taper penalty -0.2 overload = 0.3
+        self.assertAlmostEqual(score_drill(drill, "TAPER", athlete), 0.3)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename variable `athlete_tags` to `athlete_all_tags`
- remove theme tag score logic from drill scoring
- adjust overload checks to use renamed variable
- update tests for new score calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d96b54588832eb385bd1be7296d89