### PR TITLE
Add sport micro weights and parse form fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ python -m mental.program
 
 - `mental/program.py` – parses data from the *Mindcode* form and returns a
   dictionary of clean field values.
+  It captures basic athlete info such as name, age, sport and position/style
+  even if those details are not yet used by the scoring logic.
 - `mental/map_mindcode_tags.py` – converts the parsed fields into normalised
   mental performance tags such as `breath_pattern`, `reset_speed` and
   `motivation_type`.

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,0 +1,21 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from mental.program import parse_mindcode_form
+
+class ParseMindcodeFormTest(unittest.TestCase):
+    def test_basic_fields_parsed(self):
+        data = {
+            "Full name": "Jane Doe",
+            "Age": "23",
+            "Sport": "Basketball",
+            "Position/Style": "Point Guard",
+        }
+        result = parse_mindcode_form(data)
+        self.assertEqual(result["full_name"], "Jane Doe")
+        self.assertEqual(result["age"], "23")
+        self.assertEqual(result["sport"], "Basketball")
+        self.assertEqual(result["position_style"], "Point Guard")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -49,8 +49,8 @@ class ScoringTests(unittest.TestCase):
             "in_fight_camp": False,
             "tags": ["fast_reset", "breath_hold", "other"],
         }
-        # 1.0 base +0.5 phase match +0.3 sport match -0.1 overload = 1.7
-        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.7)
+        # 1.0 base +0.5 phase +0.3 sport match -0.1 overload +0.2 microweight = 1.9
+        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.9)
 
     def test_weakness_and_reinforcement_bonus(self):
         drill = {
@@ -86,6 +86,14 @@ class ScoringTests(unittest.TestCase):
         }
         # Base 1.0 -0.5 taper penalty -0.2 overload = 0.3
         self.assertAlmostEqual(score_drill(drill, "TAPER", athlete), 0.3)
+
+    def test_sport_microweight_bonus(self):
+        drill = {"theme_tags": ["fast_reset"], "modalities": ["visualisation"]}
+        athlete = {"sport": "boxing"}
+        # No phase match; microweights cancel each other so score stays base 1.0
+        self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.0)
+        # penalty for visualisation-only cancels reset bonus
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- parse basic info fields in `program.py` and note them in README
- implement sport-specific microweight bonuses and penalties in `scoring`
- adjust scoring tests for new logic and add dedicated microweight test
- add a unit test for `parse_mindcode_form`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9a400630832e9f1503e83d321e1b