### PR TITLE
Update scoring tiers and add synergy pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The scoring engine compares each drill to an athlete's traits, weaknesses and cu
 
 Scores start at **1.0** and then adjust according to the rules below. Each rule has clear caps so you know the limits without digging into the code:
 
-- **Trait scores** – Each raw trait adds a set value: base traits +0.3, elite tier&nbsp;2 +0.5, elite tier&nbsp;1 +0.7. The combined trait bonus caps at **+1.2**.
+- **Trait scores** – Each raw trait adds a set value: base traits +0.3, elite tier&nbsp;2 +0.6, elite tier&nbsp;1 +0.7. The combined trait bonus caps at **+1.2**.
 - **Phase & intensity logic** – Matching the athlete's phase adds +0.5. High intensity can deduct up to **-0.5** if the athlete is tapering or early in GPP. Fighters in camp skip these penalties.
 - **Weakness match bonus** – When drill tags hit an athlete's listed weaknesses, the score climbs by +0.1 plus +0.05 for each extra match. If the drill also uses a preferred modality, add another +0.1.
 - **Preferred modality reinforcement** – See above; it nudges the score only when a weakness match is found.

--- a/mental/scoring.py
+++ b/mental/scoring.py
@@ -4,11 +4,11 @@ TRAIT_SCORES = {
     "aggressive": 0.3,
     "resilient": 0.3,
 
-    # Elite Tier 2 (+0.5)
-    "commanding": 0.5,
-    "locked-in": 0.5,
+    # Elite Tier 2 (+0.6)
+    "commanding": 0.6,
 
     # Elite Tier 1 (+0.7)
+    "locked-in": 0.7,
     "dominates": 0.7,
     "ruthless": 0.7,
     "thrives": 0.7,
@@ -19,6 +19,7 @@ SYNERGY_LIST = {
     ("game reset", "breathwork"): {"required_tags": ["slow_reset", "emotional"]},
     ("focus drill", "journaling"): {"required_tags": ["overthink", "stage_fear"]},
     ("anchor cue", "self-talk"): {"required_tags": ["identity_gap", "control_need"]},
+    ("breathwork", "cold exposure"): {"required_tags": ["hr_up", "emotional"]},
 }
 
 ELITE_TRAITS = {"dominates", "ruthless", "thrives", "commanding", "locked-in"}
@@ -55,6 +56,11 @@ def check_synergy_match(drill: dict, athlete_all_tags):
     return False
 
 
+COMBAT_SPORTS = {"mma", "boxing", "kickboxing", "muay thai", "wrestling", "grappling", "bjj"}
+TEAM_SPORTS = {"football", "rugby", "basketball"}
+INDIVIDUAL_SPORTS = {"track"}
+
+
 def sport_microweight_bonus(drill: dict, athlete: dict) -> float:
     """Return sport-specific micro adjustment for a given drill."""
     sport = athlete.get("sport", "").lower()
@@ -65,37 +71,25 @@ def sport_microweight_bonus(drill: dict, athlete: dict) -> float:
 
     bonus = 0.0
 
-    if sport in {"mma", "boxing"}:
+    if sport in COMBAT_SPORTS:
         if tags & (FREEZE_TYPE_TAGS | RESET_SPEED_TAGS):
             bonus += 0.2
         if "visualisation" in modalities and len(modalities) == 1:
             bonus -= 0.2
 
-    elif sport in {"rugby", "football"}:
+    elif sport in TEAM_SPORTS:
         if "focus_social" in tags:
-            bonus += 0.2
-        if "focus_social" in tags and {"commanding", "playful"} & traits:
-            bonus += 0.2
+            bonus += 0.1
+            if {"commanding", "playful"} & traits:
+                bonus += 0.1
 
-    elif sport == "track":
-        if {"focus_locked", "thrives"} & tags:
+    else:  # individual or uncategorized sports
+        if "focus_locked" in tags:
             bonus += 0.2
         if phase == "GPP" and not any(
             any(k in m for k in ["breathwork", "tempo"]) for m in modalities
         ):
             bonus -= 0.2
-
-    elif sport in {"wrestling", "grappling", "bjj"}:
-        if any(
-            any(k in m for k in ["breathwork", "zone 2", "tempo"]) for m in modalities
-        ):
-            bonus += 0.2
-
-    elif sport == "basketball":
-        if {"focus_social", "decision_fear"} & tags:
-            bonus += 0.2
-        if any("game reset" in m or "cue" in m for m in modalities):
-            bonus += 0.2
 
     if bonus > 0.4:
         bonus = 0.4

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -28,7 +28,7 @@ class ScoringTests(unittest.TestCase):
         self.assertAlmostEqual(score_drill(drill, "SPP", athlete), 1.5)
         drill2 = {"intensity": "medium", "raw_traits": ["commanding"], "modalities": ["visualisation", "breathwork"]}
         athlete_synergy = {"sport": "football", "in_fight_camp": False, "tags": ["thrives"]}
-        self.assertAlmostEqual(score_drill(drill2, "SPP", athlete_synergy), 1.7)
+        self.assertAlmostEqual(score_drill(drill2, "SPP", athlete_synergy), 1.8)
 
     def test_multiple_elite_trait_penalty(self):
         drill = {"intensity": "medium", "raw_traits": ["ruthless", "commanding"], "modalities": ["focus drill"]}


### PR DESCRIPTION
## Summary
- tweak trait scores to use new tier bonuses
- add breathwork/cold exposure synergy
- update sport weight logic for combat, team and individual sports
- adjust tests for new trait weight
- mention new trait tier in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da94f7424832e9bb346c433d2de09