### PR TITLE
Add mental phase intake

### DIFF
--- a/mental/program.py
+++ b/mental/program.py
@@ -8,6 +8,15 @@ def parse_mindcode_form(fields: dict) -> dict:
     sport = get_value("Sport", fields)
     position_style = get_value("Position/Style", fields)
 
+    phase_raw = get_value("Where are you at in your performance cycle?", fields).lower()
+    phase_key = phase_raw.replace("\u2019", "'")
+    phase_mapping = {
+        "i'm rebuilding, resetting, or in off-season": "GPP",
+        "i'm training hard, sharpening up, or deep in prep": "SPP",
+        "i've got a match/event coming up or i'm easing down before game day": "TAPER",
+    }
+    mental_phase = phase_mapping.get(phase_key, "")
+
     # Multi-selects (split by ", ")
     under_pressure = [x.strip() for x in get_value("What usually happens to you under pressure? (Tick all that apply)", fields).split(",") if x.strip()]
     post_mistake = [x.strip() for x in get_value("What happens right after you make a mistake? (Tick all that apply)", fields).split(",") if x.strip()]
@@ -46,5 +55,6 @@ def parse_mindcode_form(fields: dict) -> dict:
         "reset_duration": reset_duration,
         "motivator": motivator,
         "emotional_trigger": emotional_trigger,
-        "past_mental_struggles": past_mental_struggles
+        "past_mental_struggles": past_mental_struggles,
+        "mental_phase": mental_phase
     }

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -10,12 +10,14 @@ class ParseMindcodeFormTest(unittest.TestCase):
             "Age": "23",
             "Sport": "Basketball",
             "Position/Style": "Point Guard",
+            "Where are you at in your performance cycle?": "I\u2019m rebuilding, resetting, or in off-season",
         }
         result = parse_mindcode_form(data)
         self.assertEqual(result["full_name"], "Jane Doe")
         self.assertEqual(result["age"], "23")
         self.assertEqual(result["sport"], "Basketball")
         self.assertEqual(result["position_style"], "Point Guard")
+        self.assertEqual(result["mental_phase"], "GPP")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- parse "Where are you at in your performance cycle?" from intake forms
- store value as `mental_phase` with GPP/SPP/TAPER mapping
- test for new field in `parse_mindcode_form`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dbedf09e8832e8f2e73328fa0ead3