### PR TITLE
Add decision-making field support

### DIFF
--- a/mental/map_mindcode_tags.py
+++ b/mental/map_mindcode_tags.py
@@ -108,6 +108,15 @@ EMOTIONAL_TRIGGER_MAP = {
     "i don’t know / i zoned out": "general_threat",
 }
 
+# Decision making styles
+DECISION_MAKING_MAP = {
+    "i act instantly and trust my instincts": "decide_fast",
+    "i think first, then act": "decide_think",
+    "i freeze when i have too many options": "decide_freeze",
+    "i wait for others to decide first": "decide_wait",
+    "sometimes i lead sometimes i defer": "decide_mix",
+}
+
 
 def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[str]]]:
     """Map raw form input to controlled mental performance tags."""
@@ -125,6 +134,7 @@ def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[st
         "reset_speed": "unknown",
         "motivation_type": "motivation_unknown",
         "threat_trigger": "general_threat",
+        "decision_making": "decision_unknown",
         "mental_history": "clear_history",
     }
 
@@ -158,6 +168,7 @@ def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[st
     reset_duration = form_data.get("reset_duration", "").strip().lower()
     motivator = form_data.get("motivator", "").strip().lower()
     emotional_trigger = form_data.get("emotional_trigger", "").strip().lower()
+    decision_choice = form_data.get("decision_making", "").strip().lower()
 
     lookup_pairs = [
         ("breath_pattern", BREATH_MAP, pressure_breath),
@@ -165,6 +176,7 @@ def map_mindcode_tags(form_data: Dict[str, Any]) -> Dict[str, Union[str, List[st
         ("reset_speed", RESET_SPEED_MAP, reset_duration),
         ("motivation_type", MOTIVATOR_MAP, motivator),
         ("threat_trigger", EMOTIONAL_TRIGGER_MAP, emotional_trigger),
+        ("decision_making", DECISION_MAKING_MAP, decision_choice),
     ]
     for key, mapping, value in lookup_pairs:
         if value in mapping:

--- a/mental/program.py
+++ b/mental/program.py
@@ -33,6 +33,7 @@ def parse_mindcode_form(fields: dict) -> dict:
     reset_duration = get_value("How long do you take to reset after a bad moment during performance?", fields)
     motivator = get_value("What motivates you more?", fields)
     emotional_trigger = get_value("Which one hits harder?", fields)
+    decision_making = get_value("How do you usually make decisions during performance? (Pick one)", fields)
 
     # Long text
     past_mental_struggles = get_value("Is there anything you’ve struggled with mentally in the past that’s still affecting you?", fields)
@@ -55,6 +56,7 @@ def parse_mindcode_form(fields: dict) -> dict:
         "reset_duration": reset_duration,
         "motivator": motivator,
         "emotional_trigger": emotional_trigger,
+        "decision_making": decision_making,
         "past_mental_struggles": past_mental_struggles,
         "mental_phase": mental_phase
     }

--- a/mental/tags.py
+++ b/mental/tags.py
@@ -14,6 +14,7 @@ def map_tags(form_data: Dict) -> Dict:
         "breath_pattern": "breath_unknown",
         "motivation_type": "motivation_unknown",
         "threat_trigger": "general_threat",
+        "decision_making": "decision_unknown",
         "mental_history": "clear_history",
         "preferred_modality": [],
         "struggles_with": [],
@@ -32,6 +33,7 @@ def map_tags(form_data: Dict) -> Dict:
     reset_duration = form_data.get("reset_duration", "").strip().lower()
     motivator = form_data.get("motivator", "").strip().lower()
     emotional_trigger = form_data.get("emotional_trigger", "").strip().lower()
+    decision_choice = form_data.get("decision_making", "").strip().lower()
 
     # Map tool preference and struggle lists to tags
     preferred_modality: List[str] = []
@@ -143,6 +145,20 @@ def map_tags(form_data: Dict) -> Dict:
         tags["threat_trigger"] = "audience_threat"
     else:
         tags["threat_trigger"] = "general_threat"
+
+    # --- Decision making (single-select)
+    if "instantly" in decision_choice or "instinct" in decision_choice:
+        tags["decision_making"] = "decide_fast"
+    elif "think" in decision_choice:
+        tags["decision_making"] = "decide_think"
+    elif "freeze" in decision_choice:
+        tags["decision_making"] = "decide_freeze"
+    elif "wait" in decision_choice:
+        tags["decision_making"] = "decide_wait"
+    elif "sometimes" in decision_choice:
+        tags["decision_making"] = "decide_mix"
+    else:
+        tags["decision_making"] = "decision_unknown"
 
     # --- Mental history (free text)
     if past_mental:

--- a/tags.txt
+++ b/tags.txt
@@ -9,6 +9,7 @@
     "motivation_type": ["reward_seeker", "avoid_failure", "competitive", "external_validation", "motivation_unknown"],
     "threat_trigger": ["authority_threat", "peer_threat", "audience_threat", "general_threat"],
     "mental_history": ["has_history", "clear_history"],
+    "decision_making": ["decide_fast", "decide_think", "decide_freeze", "decide_wait", "decide_mix", "decision_unknown"],
     "under_pressure": ["hesitate", "freeze", "second_guess", "emotional", "overthink", "avoidant", "audio_cutoff", "demand_avoidance", "thrives"],
     "post_mistake": ["mental_loop", "shutdown", "compensate", "disengage", "self_anger", "quick_reset", "external_judgement"],
     "focus_breakers": ["focus_crowd", "focus_coach", "focus_decision_fear", "focus_fatigue", "focus_self_critic", "focus_social", "focus_locked"],

--- a/tests/test_map_mindcode_tags.py
+++ b/tests/test_map_mindcode_tags.py
@@ -22,6 +22,7 @@ class MapMindcodeTagsTest(unittest.TestCase):
             "reset_duration": "Instantly",
             "motivator": "Small visible wins",
             "emotional_trigger": "Coach criticism",
+            "decision_making": "I think first, then act",
             "past_mental_struggles": "",
         }
         tags = map_mindcode_tags(data)
@@ -39,6 +40,7 @@ class MapMindcodeTagsTest(unittest.TestCase):
         self.assertEqual(tags["motivation_type"], "reward_seeker")
         self.assertEqual(tags["threat_trigger"], "authority_threat")
         self.assertEqual(tags["mental_history"], "clear_history")
+        self.assertEqual(tags["decision_making"], "decide_think")
 
     def test_deduplication(self):
         data = {

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -11,6 +11,7 @@ class ParseMindcodeFormTest(unittest.TestCase):
             "Sport": "Basketball",
             "Position/Style": "Point Guard",
             "Where are you at in your performance cycle?": "I\u2019m rebuilding, resetting, or in off-season",
+            "How do you usually make decisions during performance? (Pick one)": "I act instantly and trust my instincts",
         }
         result = parse_mindcode_form(data)
         self.assertEqual(result["full_name"], "Jane Doe")
@@ -18,6 +19,7 @@ class ParseMindcodeFormTest(unittest.TestCase):
         self.assertEqual(result["sport"], "Basketball")
         self.assertEqual(result["position_style"], "Point Guard")
         self.assertEqual(result["mental_phase"], "GPP")
+        self.assertEqual(result["decision_making"], "I act instantly and trust my instincts")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- parse new *decision making* question from Mindcode form
- map decision style to tags in both `map_tags` and `map_mindcode_tags`
- list `decision_making` in `tags.txt`
- test parsing and mapping of this field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddba75f90832e95455d6e5cadac12